### PR TITLE
Enable simple install

### DIFF
--- a/pyrpl/__init__.py
+++ b/pyrpl/__init__.py
@@ -1,5 +1,7 @@
 from ._version import __version_info__, __version__
 
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
 __author__ = "Leonhard Neuhaus <neuhaus@lkb.upmc.fr>"
 __license__ = "MIT License"
 

--- a/pyrpl/sshshell.py
+++ b/pyrpl/sshshell.py
@@ -50,7 +50,9 @@ class SshShell(object):
             username=self.user,
             password=self.password,
             port=self.sshport,
-            timeout=timeout)
+            timeout=timeout,
+            look_for_keys=False,
+            allow_agent=False)
         if shell:
             self.channel = self.ssh.invoke_shell()
         self.startscp()


### PR DESCRIPTION
Lets try this!  Here are a couple of commits that make it possible for me to use this repo.

**First**
ssh access fails if there are multiple keys in the .ssh host folder.
Failure: Received disconnect from 192.169.0.119 port 22:2: Too many authentication failures

This can be observed on the command line with:
ssh -v root@rp-xxxxxx

The fix on the command line is to use:

ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=password -o PubkeyAuthentication=no root@rp-xxxxxx

With paramiko module the fix is to add look_for_keys=False and allow_agent=False to the connect
**Second**
For me on Ubuntu 24.04 pip installs are broken.  I if you want to use pip then you have to add an additional parameter to the command line - 
``
python3 -m pip install  --break-system-packages
``
it is possible to run pyrpl without install. So if your project python code has "import pyrpl" and your directory structure is:
``
$ ln -s ../pyrpl/pyrpl pyrpl

$ ls -als
project.py
pyrpl -> ../pyrpl/pyrpl
``
then this fix enables you to import the pyrpl code without installing pyrpl. All you need to do is clone the latest pyrpl repository into the base folder of your project and create the symbolic link from pyrpl/pyrpl to your project folder.

This change works for python2 and python3

Here is a stack exchange discussion of this change
https://stackoverflow.com/questions/52516849/use-init-py-to-modify-sys-path-is-a-good-idea
