### PR TITLE
Update __init__.py

### DIFF
--- a/pyrpl/__init__.py
+++ b/pyrpl/__init__.py
@@ -13,8 +13,8 @@ try:
     warnings.simplefilter("ignore", np.exceptions.VisibleDeprecationWarning)
     warnings.simplefilter("error", np.exceptions.ComplexWarning)
 except AttributeError:
-    warnings.simplefilter("ignore", np.VisibleDeprecationWarning)
-    warnings.simplefilter("error", np.ComplexWarning)
+    warnings.simplefilter("ignore", np.exceptions.VisibleDeprecationWarning)
+    warnings.simplefilter("error", np.exceptions.ComplexWarning)
     
 # former issue with IIR, now resolved
 #from scipy.signal import BadCoefficients


### PR DESCRIPTION
Numpy has moved the depcation warnings to np.exceptions. This change was reflected in the 2 lines above but not in the 2 lines I editted so I have now modified it.