### PR TITLE
added support for ecosystem 2.x pyrpl fpga

### DIFF
--- a/pyrpl/redpitaya.py
+++ b/pyrpl/redpitaya.py
@@ -51,8 +51,9 @@ defaultparameters = dict(
     delay=0.05,  # delay between ssh commands - console is too slow otherwise
     autostart=True,  # autostart the client?
     reloadserver=False,  # reinstall the server at startup if not necessary?
-    reloadfpga=True,  # reload the fpga bitfile at startup?
-    serverbinfilename='fpga.bin',  # name of the binfile on the server
+    reloadfpga=True,  # reload the fpga bit.bin file at startup?
+    serverbinfilename='fpga.bit.bin',  # name of the bit.bin file on the server
+    serverdtbofilename='fpga.dtbo',  # name of the device tree overlay file on the server
     serverdirname = "//opt//pyrpl//",  # server directory for server app and bitfile
     leds_off=True,  # turn off all GPIO lets at startup (improves analog performance)
     frequency_correction=1.0,  # actual FPGA frequency is 125 MHz * frequency_correction
@@ -90,8 +91,10 @@ class RedPitaya(object):
             autostart=True,  # autostart the client?
             reloadserver=False,  # reinstall the server at startup if not necessary?
             reloadfpga=True,  # reload the fpga bitfile at startup?
-            filename='fpga//red_pitaya.bin',  # name of the bitfile for the fpga, None is default file
-            serverbinfilename='fpga.bin',  # name of the binfile on the server
+            filename='fpga//red_pitaya.bin',  # name of the bit.bin file for the fpga, None is default file
+            dtbo_filename='fpga//red_pitaya.dtbo', # name of device tree file, None is the default
+            serverbinfilename='fpga.bit.bin',  # name of the bit.bin file on the server
+            serverdbtofilename='fpga.dtbo',  # name of the device tree overlay file on the server
             serverdirname = "//opt//pyrpl//",  # server directory for server app and bitfile
             leds_off=True,  # turn off all GPIO lets at startup (improves analog performance)
             frequency_correction=1.0,  # actual FPGA frequency is 125 MHz * frequency_correction
@@ -278,12 +281,32 @@ class RedPitaya(object):
             str(gpiopin) + "/value")
         sleep(self.parameters['delay'])
 
-    def update_fpga(self, filename=None):
-        if filename is None:
+    def put_file(self, source, destination):
+        for i in range(3):
             try:
+                self.ssh.scp.put(source, destination)
+            except (SCPException, SSHException):
+                # try again before failing
+                self.start_ssh()
+                sleep(self.parameters['delay'])
+            else:
+                break
+
+    def update_fpga(self, filename=None):
+        # For version 2.0 and higher to load a custom fpga uses the update_fpga.sh script
+        update_custom = ''
+        update_cmd = '{} pyrpl'.format(
+            os.path.join(self.parameters['serverdirname'],
+                         'update_fpga.sh'))
+        if filename is None:
+            if 'filename' in self.parameters and not self.parameters['filename'] is None:
                 source = self.parameters['filename']
-            except KeyError:
+            else:
                 source = None
+
+        if not source is None and os.path.isfile(source):
+            update_custom = 'custom'
+
         self.end()
         sleep(self.parameters['delay'])
         self.ssh.ask('rw')
@@ -292,40 +315,77 @@ class RedPitaya(object):
         sleep(self.parameters['delay'])
         if source is None or not os.path.isfile(source):
             if source is not None:
-                self.logger.warning('Desired bitfile "%s" does not exist. Using default file.',
+                self.logger.warning('Desired bitfile "%s" does not exist. Using default installation.',
                                     source)
+
+            # prior to version 2.0 fpga default is to use the default pyrpl fpga
             source = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'fpga', 'red_pitaya.bin')
+
+            # after version 2.0 fpga default is to use the RedPitaya pyrpl fpga
+            update_custom = ''
+
         if not os.path.isfile(source):
             raise IOError("Wrong filename",
-              "The fpga bitfile was not found at the expected location. Try passing the arguments "
-              "dirname=\"c://github//pyrpl//pyrpl//\" adapted to your installation directory of pyrpl "
-              "and filename=\"red_pitaya.bin\"! Current dirname: "
-              + self.parameters['dirname'] +
-              " current filename: "+self.parameters['filename'])
-        for i in range(3):
-            try:
-                self.ssh.scp.put(source,
-                             os.path.join(self.parameters['serverdirname'],
-                                          self.parameters['serverbinfilename']))
-            except (SCPException, SSHException):
-                # try again before failing
-                self.start_ssh()
-                sleep(self.parameters['delay'])
-            else:
-                break
+                "The fpga bit.bin file was not found at the expected location. Try passing the arguments "
+                "filename=\"c://github//pyrpl//pyrpl//red_pitaya.bin\" adapted to your installation "
+                "directory of pyrpl: current filename: "+self.parameters['filename'])
+
+        # send update_fpga.sh to mark start of update process
+        self.put_file(
+            os.path.join(os.path.abspath(os.path.dirname(__file__)), 'update_fpga.sh'),
+            os.path.join(self.parameters['serverdirname'], 'update_fpga.sh'))
+        # send bit.bin file
+        self.put_file(source, os.path.join(self.parameters['serverdirname'],
+                                           self.parameters['serverbinfilename']))
+        if 0 < len(update_custom) and 'dtbo_filename' in self.parameters and not self.parameters['dtbo_filename'] is None:
+            # send device tree
+            update_custom = '{} dtbo'.format(update_custom)
+            if not os.path.isfile(self.parameters['dtbo_filename']):
+                raise IOError("Wrong device tree filename",
+                  "The fpga device tree was not found at the expected location. Try passing the arguments "
+                  "dtbo_filename=\"c://github//pyrpl//pyrpl//red_pitaya.dbto\" adapted to your installation "
+                  "directory of pyrpl: current filename: "+self.parameters['dtbo_filename'])
+            self.put_file(self.parameters['dtbo_filename'],
+                          os.path.join(self.parameters['serverdirname'],
+                                       self.parameters['serverdbtofilename']))
+
+        # add appropriate parameters to the update command line
+        update_cmd = '{} {}'.format(update_cmd, update_custom)
+
         # kill all other servers to prevent reading while fpga is flashed
         self.end()
         self.ssh.ask('killall nginx')
         self.ssh.ask('systemctl stop redpitaya_nginx') # for 0.94 and higher
-        self.ssh.ask('cat '
-                 + os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename'])
-                 + ' > //dev//xdevcfg')
+        sleep(3) # sleep after stopping service
+        result = self.ssh.ask('cat /root/.version')
+        self.logger.debug('cat /root/.version: {}'.format(result))
+        if result.find('2.') != -1:
+            self.ssh.ask(update_cmd)
+            sleep(1)
+        else:
+            self.ssh.ask('cat '
+                         + os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename'])
+                         + ' > //dev//xdevcfg')
+
         sleep(self.parameters['delay'])
-        self.ssh.ask('rm -f '+ os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename']))
+        self.logger.debug('About to restart the redpitaya service')
+        self.ssh.ask('rm -f '+ os.path.join(
+            self.parameters['serverdirname'], self.parameters['serverdtbofilename']))
+        self.ssh.ask('rm -f '+ os.path.join(
+            self.parameters['serverdirname'], self.parameters['serverbinfilename']))
+        self.ssh.ask('rm -f '+ os.path.join(
+            self.parameters['serverdirname'], 'update_fpga.sh'))
         self.ssh.ask("nginx -p //opt//www//")
-        self.ssh.ask('systemctl start redpitaya_nginx')  # for 0.94 and higher #needs test
+        self.ssh.ask('systemctl start redpitaya_nginx')  # for 0.94 and higher
         sleep(self.parameters['delay'])
         self.ssh.ask('ro')
+
+    def fpgaupdateinprogress(self):
+        self.ssh.ask()
+        result = self.ssh.ask('wc {}'.format(os.path.join(self.parameters['serverdirname'], 'update_fpga.sh')))
+        self.logger.debug('wc update_fpga.sh {}'.format(result))
+
+        return result.find('No such file or directory') < 0
 
     def fpgarecentlyflashed(self):
         self.ssh.ask()
@@ -393,7 +453,7 @@ class RedPitaya(object):
     def startserver(self):
         self.endserver()
         sleep(self.parameters['delay'])
-        if self.fpgarecentlyflashed():
+        if self.fpgaupdateinprogress():
             self.logger.info("FPGA is being flashed. Please wait for 2 "
                             "seconds.")
             sleep(2.0)

--- a/pyrpl/update_fpga.sh
+++ b/pyrpl/update_fpga.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+CUSTOMDEVICETREE=/opt/$1/fpga.dtbo
+CUSTOMFPGA=/opt/$1/fpga.bit.bin
+
+FPGAS=/opt/redpitaya/fpga
+MODEL=$(/opt/redpitaya/bin/monitor -f)
+
+if [ "$?" = "0" ]
+then
+sleep 0.5s
+
+FPGA_REGION=Full
+if [ "$#" -gt "3" ]
+then
+    FPGA_REGION=$4
+    rmdir /configfs/device-tree/overlays/$FPGA_REGION 2> /dev/null
+else
+    for f in /configfs/device-tree/overlays/*; do
+        # remove all existing overlay regions
+        if [ -d "$f" ]
+        then
+            rmdir $f 2> /dev/null
+        fi
+    done
+fi
+
+rm -f /tmp/update_fpga.txt 2> /dev/null
+rm -f /tmp/loaded_fpga.inf 2> /dev/null
+
+sleep 0.5s
+FPGA_INF=$1
+DEVICETREETOINSTALL=$FPGAS/$MODEL/$1/fpga.dtbo
+FPGATOINSTALL=$FPGAS/$MODEL/$1/fpga.bit.bin
+if [ "$#" -gt "1" ]
+then
+    FPGA_INF=$1_$2
+    FPGATOINSTALL=$CUSTOMFPGA
+fi
+
+if [ "$#" -gt "2" ]
+then
+    FPGA_INF=$1_$2_$3
+    DEVICETREETOINSTALL=$CUSTOMDEVICETREE
+fi
+
+MD5SUM=$(md5sum $FPGATOINSTALL)
+
+if [ "$#" -eq "1" ]
+then
+    echo -n "Commit "
+    awk 'NR==2 {print $2}' $FPGAS/$MODEL/$1/git_info.txt
+else
+    echo "Custom FPGA md5sum: $MD5SUM"
+fi
+
+/opt/redpitaya/bin/fpgautil -b $FPGATOINSTALL -o $DEVICETREETOINSTALL -n $FPGA_REGION > /tmp/update_fpga.txt 2>&1
+
+if [ "$?" = "0" ]
+then
+    echo "FPGA md5sum: $MD5SUM" >> /tmp/update_fpga.txt
+    date >> /tmp/update_fpga.txt
+    echo -n $FPGA_INF > /tmp/loaded_fpga.inf
+    exit 0
+else
+    rm -f /tmp/update_fpga.txt 2> /dev/null
+    rm -f /tmp/loaded_fpga.inf 2> /dev/null
+    exit 1
+fi
+fi
+exit 1


### PR DESCRIPTION
In the simplest use case setting reloadfpga = False in the call to Pyrpl can be used.  In this case the user has to ensure that the correct FPGA and device tree is loaded manually.  

This commit adds support for the 2.0 ecosystem and in addition allows custom FPGA's to be loaded.

To use a custom FPGA the original parameters may still be used:
```
p = Pyrpl(hostname=HOSTNAME,
    reloadfpga = True, filename = 'red_pitaya.bit.bin')
```

2.0 ecosystem uses the AMD Xilinx fpga-manager-script fpgautil to configure the device tree (Full) and load the FPGA.  In addition the 2.0 ecosystem leaves an audit trail that identifies the FPGA that has been loaded.  The file  rp-xxxxxx:/tmp/loaded_fpga.inf contains the name of the FPGA loaded.

This change conforms to this protocol and will update loaded_fpga.inf and in addition creates a separate file (rp-xxxxxx:/tmp/update_fpga.txt) with more details about the ecosystem FPGA or the custom FPGA that is in use.   The custom FPGA is provided as a parameter to Pyrpl() and optionally a custom device tree (dtbo_filename) can also be provided.  The code in this commit then handles the actual FPGA update.

This change is preferable to the pull request [518](https://github.com/pyrpl-fpga/pyrpl/pull/518) because it provides a script "update_fpga.sh" (to be run on the RedPitaya) that allows both the eco system pyrpl or a custom fpga and device tree to be loaded whilst conforming to the 2.0 ecosystem protocol.  Pull request [518](https://github.com/pyrpl-fpga/pyrpl/pull/518) leaves it up to the user to install the custom fpga and this approach has already generated support issues ( see [Modifying FPGA code in Pyrpl](https://forum.redpitaya.com/viewtopic.php?f=15&t=25502) ). 

In the simple use case mentioned above the FPGA can be loaded automatically at the start of a session and then reloadfpga set to False to prevent it being overwritten later by subsequent calls to Pyrpl().  The separate file rp-xxxxxx:/tmp/update_fpga.txt provides details of the FPGA that can be viewed on the RedPitaya hardware to confirm the details of the FPGA loaded.