### PR TITLE
add eco system v2 binfile support

### DIFF
--- a/pyrpl/update_fpga.sh
+++ b/pyrpl/update_fpga.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+CUSTOMDEVICETREE=/opt/$1/fpga.dtbo
+CUSTOMFPGA=/opt/$1/fpga.bit.bin
+
+FPGAS=/opt/redpitaya/fpga
+MODEL=$(/opt/redpitaya/bin/monitor -f)
+
+if [ "$?" = "0" ]
+then
+sleep 0.5s
+
+FPGA_REGION=Full
+if [ "$#" -gt "3" ]
+then
+    FPGA_REGION=$4
+    rmdir /configfs/device-tree/overlays/$FPGA_REGION 2> /dev/null
+else
+    for f in /configfs/device-tree/overlays/*; do
+        # remove all existing overlay regions
+        if [ -d "$f" ]
+        then
+            rmdir $f 2> /dev/null
+        fi
+    done
+fi
+
+rm -f /tmp/update_fpga.txt 2> /dev/null
+rm -f /tmp/loaded_fpga.inf 2> /dev/null
+
+sleep 0.5s
+FPGA_INF=$1
+DEVICETREETOINSTALL=$FPGAS/$MODEL/$1/fpga.dtbo
+FPGATOINSTALL=$FPGAS/$MODEL/$1/fpga.bit.bin
+if [ "$#" -gt "1" ]
+then
+    FPGA_INF=$1_$2
+    FPGATOINSTALL=$CUSTOMFPGA
+fi
+
+if [ "$#" -gt "2" ]
+then
+    FPGA_INF=$1_$2_$3
+    DEVICETREETOINSTALL=$CUSTOMDEVICETREE
+fi
+
+MD5SUM=$(md5sum $FPGATOINSTALL)
+
+if [ "$#" -eq "1" ]
+then
+    echo -n "Commit "
+    awk 'NR==2 {print $2}' $FPGAS/$MODEL/$1/git_info.txt
+else
+    echo "Custom FPGA md5sum: $MD5SUM"
+fi
+
+/opt/redpitaya/bin/fpgautil -b $FPGATOINSTALL -o $DEVICETREETOINSTALL -n $FPGA_REGION > /tmp/update_fpga.txt 2>&1
+
+if [ "$?" = "0" ]
+then
+    echo "FPGA md5sum: $MD5SUM" >> /tmp/update_fpga.txt
+    date >> /tmp/update_fpga.txt
+    echo -n $FPGA_INF > /tmp/loaded_fpga.inf
+    exit 0
+else
+    rm -f /tmp/update_fpga.txt 2> /dev/null
+    rm -f /tmp/loaded_fpga.inf 2> /dev/null
+    exit 1
+fi
+fi
+exit 1


### PR DESCRIPTION
In the simplest use case setting reloadfpga = False in the call to Pyrpl can be used.  In this case the user has to ensure that the correct FPGA and device tree is loaded manually.  

This commit adds support for the 2.0 ecosystem and in addition allows custom FPGA to be loaded.

To use a custom FPGA the original parameters may still be used:
```
p = Pyrpl(hostname=HOSTNAME,
    reloadfpga = True, filename = 'red_pitaya.bin')
```

2.0 ecosystem uses the AMD Xilinx fpga-manager-script fpgautil to configure the device tree (Full) and load the FPGA.  In addition the 2.0 ecosystem leaves an audit trail that identifies the FPGA that has been loaded.  The file  rp-xxxxxx:/tmp/loaded_fpga.inf contains the name of the FPGA loaded.

This change conforms to this protocol and will update loaded_fpga.inf and in addition creates a separate file (rp-xxxxxx:/tmp/update_fpga.txt) with more details about the ecosystem FPGA or the custom FPGA that is in use.   The custom FPGA is provided as a parameter to Pyrpl().  The code in this commit then handles the actual FPGA update.

This change is preferable to the pull request [518](https://github.com/pyrpl-fpga/pyrpl/pull/518) because it provides a script "update_fpga.sh" (to be run on the RedPitaya) that allows both the eco system pyrpl or a custom fpga to be loaded whilst conforming to the 2.0 ecosystem protocol.  Pull request [518](https://github.com/pyrpl-fpga/pyrpl/pull/518) leaves it up to the user to install the custom fpga and this approach has already generated support issues ( see [Modifying FPGA code in Pyrpl](https://forum.redpitaya.com/viewtopic.php?f=15&t=25502) ). 

In the simple use case mentioned above the FPGA can be loaded automatically at the start of a session and then reloadfpga set to False to prevent it being overwritten later by subsequent calls to Pyrpl().  The separate file rp-xxxxxx:/tmp/update_fpga.txt provides details of the FPGA that can be viewed on the RedPitaya hardware to confirm the details of the FPGA loaded.

Note that the device tree is provided by the v2.0 ecosystem so any custom FPGA must be developed accordingly.