### PR TITLE
updated fpga build to Vitis / Vivado v2023.2

### DIFF
--- a/pyrpl/fpga/Makefile
+++ b/pyrpl/fpga/Makefile
@@ -3,30 +3,74 @@
 # Authors: Matej Oblak, Iztok Jeras
 # (C) Red Pitaya 2013-2015
 #
-# Red Pitaya FPGA/SoC Makefile 
+# Red Pitaya FPGA/SoC Makefile
 #
 
+VIVADO_VER := $(shell vivado -version | head -n 1 | sed -e 's/ (/_/g' | sed -e 's/ /_/g' | sed -e 's/)//g')
+
+PARENT  = ../../..
+VITIS_VER = 2023.2
+DTG     = $(PARENT)/device-tree-xlnx-xilinx-v$(VITIS_VER)
+
+# Red Pitaya FPGA repo
+RP_VER  = Release-2024.3
+RPFPGA  = $(PARENT)/RedPitaya-FPGA
+
 # build results
-FPGA_BIN=out/red_pitaya.bin
+OUT_DIR=out
+FPGA_BIN=$(OUT_DIR)/red_pitaya.bin
+FPGA_DTBO=$(OUT_DIR)/red_pitaya.dtbo
 
 #logfile for stdout and stderr
 LOG=>> fpga.log 2>&1
 
 # Vivado from Xilinx provides IP handling, FPGA compilation
-# hsi (hardware software interface) provides software integration
+# Vitis / xsct provide software integration
 # both tools are run in batch mode with an option to avoid log/journal files
 VIVADO = vivado -nolog -nojournal -mode batch
+DTS_DIR = sdk/dts
+PL_DEVICE_TREE = $(DTS_DIR)/pl.dtsi
 
-all: clean $(FPGA_BIN) postclean
+all: $(FPGA_BIN) $(FPGA_DTBO) postclean
 
-clean:
-	rm -rf out .Xil .srcs sdk
+ifeq ($(VIVADO_VER),)
+$(error "Vivado not detected: setup environment with source /opt/Xilinx/Vivado/$(VITIS_VER)/settings64.sh")
+endif
+
+ifneq ($(VIVADO_VER),vivado_v$(VITIS_VER)_64-bit)
+$(error "Vivado version $(VIVADO_VER) consider changing DTG version $(VITIS_VER)")
+endif
 
 $(FPGA_BIN):
 	$(VIVADO) -source red_pitaya_vivado.tcl $(LOG)
 
+# required for the device tree creation
+$(DTG):
+	git clone https://github.com/Xilinx/device-tree-xlnx.git $(DTG)
+	@cd $(DTG); git checkout xilinx_v$(VITIS_VER) $(LOG)
+
+# required for the device tree creation
+$(RPFPGA):
+	git clone https://github.com/RedPitaya/RedPitaya-FPGA.git $(RPFPGA)
+	@cd $(RPFPGA); git checkout $(RP_VER) $(LOG)
+
+# device tree overlay creation
+$(FPGA_DTBO): $(DTG) $(RPFPGA)
+	xsct xsct_hsi_dtb.tcl DTG_VER=$(VITIS_VER) $(LOG)
+
+#fix bug with #address-cells and #size-cells for overlay
+	sed -i 's/#address-cells/\/\/#address-cells/g' $(DTS_DIR)/pl.dtsi
+	sed -i 's/#size-cells/\/\/#size-cells/g' $(DTS_DIR)/pl.dtsi
+	sed -i 's/red_pitaya.bit.bin/fpga.bit.bin/g' $(DTS_DIR)/pl.dtsi
+
+	dtc -@ -O dtb -o $(FPGA_DTBO) -i $(DTS_DIR) -i $(RPFPGA)/dts $(PL_DEVICE_TREE) $(LOG)
+	dtc -I dtb -O dts $(OUT_DIR)/red_pitaya.dtbo -o $(OUT_DIR)/red_pitaya.dts $(LOG)
+
 postclean:
-	mv *.xml out/
-	mv *.prm out/
-	mv *.html out/
-	mv *.log out/
+	cp $(FPGA_BIN) $(FPGA_DTBO) .
+	cp .gen/sources_1/bd/system/ip/system_processing_system7_0/*.html $(OUT_DIR)
+	cp sdk/red_pitaya.hwh $(OUT_DIR)
+	mv *.log $(OUT_DIR)
+
+clean:
+	rm -rf out .Xil .srcs .gen sdk

--- a/pyrpl/fpga/Makefile
+++ b/pyrpl/fpga/Makefile
@@ -9,7 +9,7 @@
 VIVADO_VER := $(shell vivado -version | head -n 1 | sed -e 's/ (/_/g' | sed -e 's/ /_/g' | sed -e 's/)//g')
 
 PARENT  = ../../..
-VITIS_VER = 2023.2
+VITIS_VER = 2024.2
 DTG     = $(PARENT)/device-tree-xlnx-xilinx-v$(VITIS_VER)
 
 # Red Pitaya FPGA repo

--- a/pyrpl/fpga/README.md
+++ b/pyrpl/fpga/README.md
@@ -15,7 +15,10 @@
 
 # Build process
 
-Update the part number and sdc file specific to your target board in `fpga/red_pitaya_vivado.tcl`
+> [!NOTE]
+> First consider using the fpga build scripts in [RedPitaya/Makefile.x86](https://github.com/RedPitaya/RedPitaya/blob/master/Makefile.x86) that supports all the different RedPitaya board types using the [RedPitaya-FPGA](https://github.com/RedPitaya/RedPitaya-FPGA) hdl code rather than this fpga build.
+
+Assuming you have a specific requirement to use this hdl code rather than the RedPitaya-FPGA hdl code in your design make sure that you update the part number and constraints sdc file specific to your target board in `fpga/red_pitaya_vivado.tcl`
 ```
 set part xc7z010clg400-1
 read_xdc                          $path_sdc/red_pitaya.xdc
@@ -33,22 +36,22 @@ set scripts_vivado_version 2023.2
 
 The default mode for building the FPGA is to run a TCL script inside Vivado. Non project mode is used, to avoid the generation of project files, which are too many and difficult to handle. This allows us to only place source files and scripts under version control.
 
-The next scripts perform various tasks:
+The next scripts perform various tasks for the xc7z010clg400-1 part:
 
 | TCL script                      | action
 |---------------------------------|---------------------------------------------
 | `red_pitaya_vivado_project.tcl` | creates a Vivado project for graphical editing
 | `red_pitaya_vivado.tcl`         | creates the bitstream and reports
 
-To generate a redpitaya.bin file, redpitaya.dtbo device tree, reports, run these two commands:
+To generate a redpitaya.bin file for the xc7z010clg400-1 part, redpitaya.dtbo device tree, reports, run these two commands:
 ```bash
 source /opt/Xilinx/Vivado/2023.2/settings64.sh
 make
 ```
 
 # Device tree
-
-You do not need to build the .bin file or the device tree to use Pyrpl.  They are provided pre-built.
+> [!NOTE]
+> You do not need to build the .bin file or the device tree to use Pyrpl.  They are provided pre-built.
 
 Device tree is used by Linux to describe features and address space of memory mapped hardware attached to the CPU.  It can (optionally) be installed onto the RedPitaya board with the redpitaya.bin file generated (specify the full path to the files).  In this example assuming the generated .bin and .dtbo files are in the same directory as the python code:
 ```

--- a/pyrpl/fpga/README.md
+++ b/pyrpl/fpga/README.md
@@ -1,24 +1,34 @@
 # Directory structure
 
-|  path           | contents
-|-----------------|-------------------------------------------------------------
-| `fpga/Makefile` | main Makefile, used to run FPGA related tools
-| `fpga/*.tcl`    | TCL scripts to be run inside FPGA tools
-| `fpga/archive/` | archive of XZ compressed FPGA bit files
-| `fpga/doc/`     | documentation (block diagrams, address space, ...)
-| `fpga/ip/`      | third party IP, for now Zynq block diagrams
-| `fpga/rtl/`     | Verilog (SystemVerilog) "Register-Transfer Level"
-| `fpga/sdc/`     | "Synopsys Design Constraints" contains Xilinx design constraints
-| `fpga/sim/`     | simulation scripts
-| `fpga/tbn/`     | Verilog (SystemVerilog) "test bench"
-|                 |
-| `fpga/hsi/`     | "Hardware Software Interface" contains FSBL (First Stage Boot Loader) and DTS (Design Tree) builds
+|  path             | contents
+|-------------------|-------------------------------------------------------------
+| `fpga/Makefile`   | main Makefile, used to run FPGA related tools
+| `fpga/*.tcl`      | TCL scripts to be run inside FPGA tools
+| `fpga/ip/`        | third party IP, for now Zynq block diagrams
+| `fpga/rtl/`       | Verilog (SystemVerilog) "Register-Transfer Level"
+| `fpga/sdc/`       | "Synopsys Design Constraints" contains Xilinx design constraints
+| `fpga/sim/`       | simulation scripts
+| `fpga/tbn/`       | Verilog (SystemVerilog) "test bench"
+|                   |
+| `fpga/sdk/`       | generated red_pitaya.xsa file used to create a Vitis project
+| `fpga/out`        | generated logs and other significant artifacts from the build
 
 # Build process
 
-Xilinx Vivado 2015.4 (including SDK) is required. If installed at the default location, then the next command will properly configure system variables:
+Update the part number and sdc file specific to your target board in `fpga/red_pitaya_vivado.tcl`
+```
+set part xc7z010clg400-1
+read_xdc                          $path_sdc/red_pitaya.xdc
+```
+
+Xilinx Vitis / Vivado 2023.2 is required. If installed at the default location, then the next command will properly configure system variables:
 ```bash
-. /opt/Xilinx/Vivado/2015.4/settings64.sh
+. /opt/Xilinx/Vivado/2023.2/settings64.sh
+```
+
+If you need to update to a more recent version of Vitis / Vivado then update the Vivado version in `fpga/ip/system_bd.tcl` - be prepared to fix up various build tcl scripts to replace depreciated tcl commands
+```
+set scripts_vivado_version 2023.2
 ```
 
 The default mode for building the FPGA is to run a TCL script inside Vivado. Non project mode is used, to avoid the generation of project files, which are too many and difficult to handle. This allows us to only place source files and scripts under version control.
@@ -27,31 +37,28 @@ The next scripts perform various tasks:
 
 | TCL script                      | action
 |---------------------------------|---------------------------------------------
-| `red_pitaya_hsi_dram_test.tcl`  | should create the `zynq_dram_test` but the produced binary can not be run from a SD card
-| `red_pitaya_hsi_dts.tcl`        | creates device tree sources
-| `red_pitaya_hsi_fsbl.tcl`       | creates FSBL executable binary
 | `red_pitaya_vivado_project.tcl` | creates a Vivado project for graphical editing
 | `red_pitaya_vivado.tcl`         | creates the bitstream and reports
 
-To generate a bit file, reports, device tree and FSBL, run these two commands:
+To generate a redpitaya.bin file, redpitaya.dtbo device tree, reports, run these two commands:
 ```bash
-source /opt/Xilinx/Vivado/2015.4/settings64.sh
+source /opt/Xilinx/Vivado/2023.2/settings64.sh
 make
 ```
 
 # Device tree
 
-Device tree is used by Linux to describe features and address space of memory mapped hardware attached to the CPU.
+You do not need to build the .bin file or the device tree to use Pyrpl.  They are provided pre-built.
 
-Running `make` inside this directory will create a device tree source and some include files:
-
-| device tree file | contents
-|------------------|------------------------------------------------------------
-| `zynq-7000.dtsi` | description of peripherals inside PS (processing system)
-| `pl.dtsi`        | description of AXI attached peripherals inside PL (programmable logic)
-| `system.dts`     | description of all peripherals, includes the above `*.dtsi` files
-
-To enable some Linux drivers (Ethernet, XADC, I2C EEPROM, SPI, GPIO and LED) the device tree source is patched using `../patches/devicetree.patch`.
+Device tree is used by Linux to describe features and address space of memory mapped hardware attached to the CPU.  It can (optionally) be installed onto the RedPitaya board with the redpitaya.bin file generated (specify the full path to the files).  In this example assuming the generated .bin and .dtbo files are in the same directory as the python code:
+```
+from pyrpl import Pyrpl
+p = Pyrpl(hostname=HOSTNAME,
+    reloadfpga = True, filename = 'red_pitaya.bin',
+    dtbo_filename = 'red_pitaya.dtbo'
+    )
+```
+The pre-built .bin file and device tree are used if these files are not specified.  You can avoid reloading the fpga files each time you run your script by setting reloadfpga = False.  If you use the config, configuration file attribute, then the attributes that are used are stored in a .yaml file in the PYRPL_USER_DIR so next time you start your application the settings including reloadfpga will be restored.
 
 # Signal mapping
 

--- a/pyrpl/fpga/clockInfo.txt
+++ b/pyrpl/fpga/clockInfo.txt
@@ -1,0 +1,10 @@
+-------------------------------------
+| Tool Version : Vivado v.2024.2
+| Date         : Wed Feb 19 13:25:22 2025
+| Host         : fontana
+| Design       : design_1
+| Device       : xc7z010-clg400-1--
+-------------------------------------
+
+For more information on clockInfo.txt clock routing debug file see https://support.xilinx.com/s/article/000035660?language=en_US
+

--- a/pyrpl/fpga/ip/system.bd
+++ b/pyrpl/fpga/ip/system.bd
@@ -1595,7 +1595,7 @@
       </spirit:componentInstance>
       <spirit:componentInstance>
         <spirit:instanceName>xadc</spirit:instanceName>
-        <spirit:componentRef spirit:library="ip" spirit:name="xadc_wiz" spirit:vendor="xilinx.com" spirit:version="3.2"/>
+        <spirit:componentRef spirit:library="ip" spirit:name="xadc_wiz" spirit:vendor="xilinx.com" spirit:version="3.3"/>
         <spirit:configurableElementValues>
           <spirit:configurableElementValue spirit:referenceId="bd:xciName">system_xadc_0</spirit:configurableElementValue>
           <spirit:configurableElementValue spirit:referenceId="XADC_STARUP_SELECTION">independent_adc</spirit:configurableElementValue>

--- a/pyrpl/fpga/ip/system_bd.tcl
+++ b/pyrpl/fpga/ip/system_bd.tcl
@@ -10,7 +10,7 @@
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2023.2
+set scripts_vivado_version 2024.2
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {

--- a/pyrpl/fpga/ip/system_bd.tcl
+++ b/pyrpl/fpga/ip/system_bd.tcl
@@ -10,7 +10,7 @@
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2015.4
+set scripts_vivado_version 2023.2
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -343,18 +343,20 @@ CONFIG.PCW_USE_S_AXI_HP1 {1} \
  ] $processing_system7
 
   # Create instance: xadc, and set properties
-  set xadc [ create_bd_cell -type ip -vlnv xilinx.com:ip:xadc_wiz:3.2 xadc ]
+  set xadc [ create_bd_cell -type ip -vlnv xilinx.com:ip:xadc_wiz:3.3 xadc ]
   set_property -dict [ list \
-CONFIG.CHANNEL_ENABLE_VAUXP0_VAUXN0 {true} \
-CONFIG.CHANNEL_ENABLE_VAUXP1_VAUXN1 {true} \
-CONFIG.CHANNEL_ENABLE_VAUXP8_VAUXN8 {true} \
-CONFIG.CHANNEL_ENABLE_VAUXP9_VAUXN9 {true} \
-CONFIG.CHANNEL_ENABLE_VP_VN {true} \
-CONFIG.ENABLE_AXI4STREAM {false} \
-CONFIG.EXTERNAL_MUX_CHANNEL {VP_VN} \
-CONFIG.SEQUENCER_MODE {Off} \
-CONFIG.SINGLE_CHANNEL_SELECTION {TEMPERATURE} \
-CONFIG.XADC_STARUP_SELECTION {independent_adc} \
+   CONFIG.CHANNEL_ENABLE_VAUXP0_VAUXN0 {true} \
+   CONFIG.CHANNEL_ENABLE_VAUXP1_VAUXN1 {true} \
+   CONFIG.CHANNEL_ENABLE_VAUXP8_VAUXN8 {true} \
+   CONFIG.CHANNEL_ENABLE_VAUXP9_VAUXN9 {true} \
+   CONFIG.CHANNEL_ENABLE_VP_VN {true} \
+   CONFIG.ENABLE_AXI4STREAM {false} \
+   CONFIG.ENABLE_RESET {false} \
+   CONFIG.EXTERNAL_MUX_CHANNEL {VP_VN} \
+   CONFIG.INTERFACE_SELECTION {Enable_AXI} \
+   CONFIG.SEQUENCER_MODE {Off} \
+   CONFIG.SINGLE_CHANNEL_SELECTION {TEMPERATURE} \
+   CONFIG.XADC_STARUP_SELECTION {independent_adc} \
  ] $xadc
 
   # Create instance: xlconstant, and set properties

--- a/pyrpl/fpga/make.bat
+++ b/pyrpl/fpga/make.bat
@@ -3,6 +3,6 @@
 @RD /S /Q .srcs
 @RD /S /Q sdk
 
-c:/Xilinx/Vivado/2023.2/bin/vivado.bat -nolog -nojournal -mode tcl -source red_pitaya_vivado.tcl
+c:/Xilinx/Vivado/2024.2/bin/vivado.bat -nolog -nojournal -mode tcl -source red_pitaya_vivado.tcl
 
 echo compilation finished

--- a/pyrpl/fpga/make.bat
+++ b/pyrpl/fpga/make.bat
@@ -3,6 +3,6 @@
 @RD /S /Q .srcs
 @RD /S /Q sdk
 
-c:/Xilinx/Vivado/2015.4/bin/vivado.bat -nolog -nojournal -mode tcl -source red_pitaya_vivado.tcl
+c:/Xilinx/Vivado/2023.2/bin/vivado.bat -nolog -nojournal -mode tcl -source red_pitaya_vivado.tcl
 
 echo compilation finished

--- a/pyrpl/fpga/out/clock_util.rpt
+++ b/pyrpl/fpga/out/clock_util.rpt
@@ -1,187 +1,324 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
------------------------------------------------------------------------------------------
-| Tool Version      : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date              : Fri Mar 17 14:13:55 2023
-| Host              : fontana running 64-bit major release  (build 9200)
-| Command           : report_clock_utilization -file out/clock_util.rpt
-| Design            : red_pitaya_top
-| Device            : 7z010-clg400
-| Speed File        : -1  PRODUCTION 1.11 2014-09-11
-| Temperature Grade : C
------------------------------------------------------------------------------------------
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:33:47 2025
+| Host         : fontana running 64-bit major release  (build 9200)
+| Command      : report_clock_utilization -file out/clock_util.rpt
+| Design       : red_pitaya_top
+| Device       : 7z010-clg400
+| Speed File   : -1  PRODUCTION 1.12 2019-11-22
+| Design State : Routed
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Clock Utilization Report
 
 Table of Contents
 -----------------
 1. Clock Primitive Utilization
-2. Details of Global Clocks
-3. Details of Regional Clocks
-4. Details of Multi-Regional Clocks
-5. Details of I/O Clocks
-6. Details of Local Clocks
-7. Clock Regions : Key Resource Utilization
-8. Net wise resources used in clock region X0Y0
-9. Net wise resources used in clock region X1Y0
-10. Net wise resources used in clock region X0Y1
-11. Net wise resources used in clock region X1Y1
+2. Global Clock Resources
+3. Global Clock Source Details
+4. Local Clock Details
+5. Clock Regions: Key Resource Utilization
+6. Clock Regions : Global Clock Summary
+7. Device Cell Placement Summary for Global Clock g0
+8. Device Cell Placement Summary for Global Clock g1
+9. Device Cell Placement Summary for Global Clock g2
+10. Device Cell Placement Summary for Global Clock g3
+11. Device Cell Placement Summary for Global Clock g4
+12. Device Cell Placement Summary for Global Clock g5
+13. Clock Region Cell Placement per Global Clock: Region X0Y0
+14. Clock Region Cell Placement per Global Clock: Region X1Y0
+15. Clock Region Cell Placement per Global Clock: Region X0Y1
+16. Clock Region Cell Placement per Global Clock: Region X1Y1
 
 1. Clock Primitive Utilization
 ------------------------------
 
-+-------+------+-----------+-----------+
-| Type  | Used | Available | Num Fixed |
-+-------+------+-----------+-----------+
-| BUFG  |    6 |        32 |         0 |
-| BUFH  |    0 |        48 |         0 |
-| BUFIO |    0 |         8 |         0 |
-| MMCM  |    0 |         2 |         0 |
-| PLL   |    1 |         2 |         0 |
-| BUFR  |    0 |         8 |         0 |
-| BUFMR |    0 |         4 |         0 |
-+-------+------+-----------+-----------+
++----------+------+-----------+-----+--------------+--------+
+| Type     | Used | Available | LOC | Clock Region | Pblock |
++----------+------+-----------+-----+--------------+--------+
+| BUFGCTRL |    6 |        32 |   0 |            0 |      0 |
+| BUFH     |    0 |        48 |   0 |            0 |      0 |
+| BUFIO    |    0 |         8 |   0 |            0 |      0 |
+| BUFMR    |    0 |         4 |   0 |            0 |      0 |
+| BUFR     |    0 |         8 |   0 |            0 |      0 |
+| MMCM     |    0 |         2 |   0 |            0 |      0 |
+| PLL      |    1 |         2 |   0 |            0 |      0 |
++----------+------+-----------+-----+--------------+--------+
 
 
-2. Details of Global Clocks
----------------------------
+2. Global Clock Resources
+-------------------------
 
-+-------+----------------------------------------------------------------------------------+----------------------------------------------------------+---------------+-------+
-|       |                                                                                  |                                                          |   Num Loads   |       |
-+-------+----------------------------------------------------------------------------------+----------------------------------------------------------+-------+-------+-------+
-| Index | BUFG Cell                                                                        | Net Name                                                 |  BELs | Sites | Fixed |
-+-------+----------------------------------------------------------------------------------+----------------------------------------------------------+-------+-------+-------+
-|     1 | bufg_dac_clk_2p                                                                  | dac_clk_2p                                               |     1 |     1 |    no |
-|     2 | bufg_dac_clk_2x                                                                  | dac_clk_2x                                               |     1 |     1 |    no |
-|     3 | bufg_dac_clk_1x                                                                  | dac_clk_1x                                               |    45 |    38 |    no |
-|     4 | bufg_pwm_clk                                                                     | pwm_clk                                                  |   215 |    61 |    no |
-|     5 | i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |   851 |   296 |    no |
-|     6 | bufg_adc_clk                                                                     | adc_clk                                                  | 13348 |  3908 |    no |
-+-------+----------------------------------------------------------------------------------+----------------------------------------------------------+-------+-------+-------+
-
-
-+-------+----------+----------------+--------------+-------+
-|       |          |                |   Num Loads  |       |
-+-------+----------+----------------+------+-------+-------+
-| Index | PLL Cell | Net Name       | BELs | Sites | Fixed |
-+-------+----------+----------------+------+-------+-------+
-|     1 | pll/pll  | pll/clk_adc    |    1 |     1 |    no |
-|     2 | pll/pll  | pll/clk_dac_1x |    1 |     1 |    no |
-|     3 | pll/pll  | pll/clk_dac_2p |    1 |     1 |    no |
-|     4 | pll/pll  | pll/clk_dac_2x |    1 |     1 |    no |
-|     5 | pll/pll  | pll/clk_fb     |    1 |     1 |    no |
-|     6 | pll/pll  | pll/clk_pwm    |    1 |     1 |    no |
-+-------+----------+----------------+------+-------+-------+
++-----------+-----------+-----------------+------------+---------------+--------------+-------------------+-------------+-----------------+--------------+----------------+------------------------------------------------------------------------------------+----------------------------------------------------------+
+| Global Id | Source Id | Driver Type/Pin | Constraint | Site          | Clock Region | Load Clock Region | Clock Loads | Non-Clock Loads | Clock Period | Clock          | Driver Pin                                                                         | Net                                                      |
++-----------+-----------+-----------------+------------+---------------+--------------+-------------------+-------------+-----------------+--------------+----------------+------------------------------------------------------------------------------------+----------------------------------------------------------+
+| g0        | src0      | BUFG/O          | None       | BUFGCTRL_X0Y0 | n/a          |                 4 |       13349 |               0 |        8.000 | pll_adc_clk    | bufg_adc_clk/O                                                                     | adc_clk                                                  |
+| g1        | src1      | BUFG/O          | None       | BUFGCTRL_X0Y1 | n/a          |                 1 |         751 |               0 |        5.000 | clk_fpga_3     | i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |
+| g2        | src2      | BUFG/O          | None       | BUFGCTRL_X0Y2 | n/a          |                 1 |         215 |               0 |        4.000 | pll_pwm_clk    | bufg_pwm_clk/O                                                                     | pwm_clk                                                  |
+| g3        | src3      | BUFG/O          | None       | BUFGCTRL_X0Y3 | n/a          |                 1 |          45 |               0 |        8.000 | pll_dac_clk_1x | bufg_dac_clk_1x/O                                                                  | dac_clk_1x                                               |
+| g4        | src4      | BUFG/O          | None       | BUFGCTRL_X0Y4 | n/a          |                 1 |           1 |               0 |        4.000 | pll_dac_clk_2p | bufg_dac_clk_2p/O                                                                  | dac_clk_2p                                               |
+| g5        | src5      | BUFG/O          | None       | BUFGCTRL_X0Y5 | n/a          |                 1 |           1 |               0 |        4.000 | pll_dac_clk_2x | bufg_dac_clk_2x/O                                                                  | dac_clk_2x                                               |
++-----------+-----------+-----------------+------------+---------------+--------------+-------------------+-------------+-----------------+--------------+----------------+------------------------------------------------------------------------------------+----------------------------------------------------------+
+* Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+** Non-Clock Loads column represents cell count of non-clock pin loads
 
 
-3. Details of Regional Clocks
------------------------------
+3. Global Clock Source Details
+------------------------------
 
-4. Details of Multi-Regional Clocks
------------------------------------
-
-5. Details of I/O Clocks
-------------------------
-
-6. Details of Local Clocks
---------------------------
-
-+-------+------------------+--------------+--------------+-------+
-|       |                  |              |   Num Loads  |       |
-+-------+------------------+--------------+------+-------+-------+
-| Index | Local Clk Src    | Net Name     | BELs | Sites | Fixed |
-+-------+------------------+--------------+------+-------+-------+
-|     1 | i_clk            | adc_clk_in   |    1 |     1 |   yes |
-|     2 | i_hk/dna_clk_reg | i_hk/dna_clk |    1 |     1 |    no |
-+-------+------------------+--------------+------+-------+-------+
++-----------+-----------+-------------------+------------+----------------+--------------+-------------+-----------------+---------------------+----------------+-----------------------------------------------------------------+-----------------------------------------------------------------------+
+| Source Id | Global Id | Driver Type/Pin   | Constraint | Site           | Clock Region | Clock Loads | Non-Clock Loads | Source Clock Period | Source Clock   | Driver Pin                                                      | Net                                                                   |
++-----------+-----------+-------------------+------------+----------------+--------------+-------------+-----------------+---------------------+----------------+-----------------------------------------------------------------+-----------------------------------------------------------------------+
+| src0      | g0        | PLLE2_ADV/CLKOUT0 | None       | PLLE2_ADV_X0Y0 | X1Y0         |           1 |               0 |               8.000 | pll_adc_clk    | pll/pll/CLKOUT0                                                 | pll/clk_adc                                                           |
+| src1      | g1        | PS7/FCLKCLK[3]    | PS7_X0Y0   | PS7_X0Y0       | X0Y1         |           1 |               0 |               5.000 | clk_fpga_3     | i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3] | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3] |
+| src2      | g2        | PLLE2_ADV/CLKOUT5 | None       | PLLE2_ADV_X0Y0 | X1Y0         |           1 |               0 |               4.000 | pll_pwm_clk    | pll/pll/CLKOUT5                                                 | pll/clk_pwm                                                           |
+| src3      | g3        | PLLE2_ADV/CLKOUT1 | None       | PLLE2_ADV_X0Y0 | X1Y0         |           1 |               0 |               8.000 | pll_dac_clk_1x | pll/pll/CLKOUT1                                                 | pll/clk_dac_1x                                                        |
+| src4      | g4        | PLLE2_ADV/CLKOUT3 | None       | PLLE2_ADV_X0Y0 | X1Y0         |           1 |               0 |               4.000 | pll_dac_clk_2p | pll/pll/CLKOUT3                                                 | pll/clk_dac_2p                                                        |
+| src5      | g5        | PLLE2_ADV/CLKOUT2 | None       | PLLE2_ADV_X0Y0 | X1Y0         |           1 |               0 |               4.000 | pll_dac_clk_2x | pll/pll/CLKOUT2                                                 | pll/clk_dac_2x                                                        |
++-----------+-----------+-------------------+------------+----------------+--------------+-------------+-----------------+---------------------+----------------+-----------------------------------------------------------------+-----------------------------------------------------------------------+
+* Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+** Non-Clock Loads column represents cell count of non-clock pin loads
 
 
-7. Clock Regions : Key Resource Utilization
--------------------------------------------
+4. Local Clock Details
+----------------------
+
++----------+-----------------+------------+-----------------+--------------+-------------+-----------------+--------------+-------+--------------------+--------------+
+| Local Id | Driver Type/Pin | Constraint | Site/BEL        | Clock Region | Clock Loads | Non-Clock Loads | Clock Period | Clock | Driver Pin         | Net          |
++----------+-----------------+------------+-----------------+--------------+-------------+-----------------+--------------+-------+--------------------+--------------+
+| 0        | FDRE/Q          | None       | SLICE_X9Y48/AFF | X0Y0         |           1 |               0 |              |       | i_hk/dna_clk_reg/Q | i_hk/dna_clk |
++----------+-----------------+------------+-----------------+--------------+-------------+-----------------+--------------+-------+--------------------+--------------+
+* Local Clocks in this context represents only clocks driven by non-global buffers
+** Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+*** Non-Clock Loads column represents cell count of non-clock pin loads
+
+
+5. Clock Regions: Key Resource Utilization
+------------------------------------------
 
 +-------------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+--------------+
-|                   | Global Clock |     BUFRs    |    BUFMRs    |    BUFIOs    |     MMCM     |      PLL     |      GT      |      PCI     |    ILOGIC    |    OLOGIC    |      FF      |     LUTM     |    RAMB18    |    RAMB36    |    DSP48E1   |
+|                   | Global Clock |     BUFRs    |    BUFMRs    |    BUFIOs    |     MMCM     |      PLL     |      GT      |      PCI     |    ILOGIC    |    OLOGIC    |      FF      |     LUTM     |    RAMB18    |    RAMB36    |    DSP48E2   |
 +-------------------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+
 | Clock Region Name | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail | Used | Avail |
 +-------------------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+
-| X0Y0              |    3 |    12 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 | 4024 |  8800 |   48 |  1600 |    0 |    20 |    2 |    10 |   19 |    20 |
-| X1Y0              |    2 |    12 |    0 |     4 |    0 |     2 |    0 |     4 |    0 |     1 |    1 |     1 |    0 |     0 |    0 |     0 |   28 |    50 |    4 |    50 | 3799 |  8800 |    0 |  1400 |    0 |    40 |    4 |    20 |   19 |    20 |
-| X0Y1              |    3 |    12 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 | 3434 |  8800 |   71 |  1600 |    0 |    20 |   10 |    10 |    1 |    20 |
-| X1Y1              |    6 |    12 |    0 |     4 |    0 |     2 |    0 |     4 |    0 |     1 |    0 |     1 |    0 |     0 |    0 |     0 |    0 |    50 |   18 |    50 | 2978 |  8800 |    0 |  1400 |    0 |    40 |   18 |    20 |    7 |    20 |
+| X0Y0              |    1 |    12 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 | 3845 |  1100 | 1408 |   400 |    0 |    20 |    5 |    10 |    4 |    20 |
+| X1Y0              |    2 |    12 |    0 |     4 |    0 |     2 |    0 |     4 |    0 |     1 |    0 |     1 |    0 |     0 |    0 |     0 |   28 |    50 |    4 |    50 | 3746 |  1100 | 1156 |   350 |    0 |    40 |    9 |    20 |    4 |    20 |
+| X0Y1              |    2 |    12 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 |    0 |     0 | 3534 |  1100 | 1372 |   400 |    0 |    20 |    9 |    10 |    6 |    20 |
+| X1Y1              |    4 |    12 |    0 |     4 |    0 |     2 |    0 |     4 |    0 |     1 |    0 |     1 |    0 |     0 |    0 |     0 |    0 |    50 |   18 |    50 | 3111 |  1100 |  974 |   350 |    0 |    40 |   11 |    20 |    6 |    20 |
 +-------------------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+------+-------+
-* RAMB36 site can be used as two RAMB18/FIFO18 sites.
+* Global Clock column represents track count; while other columns represents cell counts
 
 
-8. Net wise resources used in clock region X0Y0
------------------------------------------------
+6. Clock Regions : Global Clock Summary
+---------------------------------------
 
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-| Source Type | BUFHCE Site  | Fixed | MMCM Pins | PLL Pins | GT Pins | BRAM Pins | ILOGICs | OLOGICs |  FFs | LUTMs | DSP48E1s |                      Clock Net Name                      |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-| BUFG        | BUFHCE_X0Y8  |   no  |         0 |        0 |       0 |         0 |       0 |       0 |    4 |     0 |        0 | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |
-| BUFG        | BUFHCE_X0Y10 |   no  |         0 |        0 |       0 |         0 |       0 |       0 |   72 |     0 |        0 | pwm_clk                                                  |
-| BUFG        | BUFHCE_X0Y9  |   no  |         0 |        0 |       0 |         4 |       0 |       0 | 3948 |    48 |        4 | adc_clk                                                  |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-
-
-9. Net wise resources used in clock region X1Y0
------------------------------------------------
-
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------+
-| Source Type | BUFHCE Site  | Fixed | MMCM Pins | PLL Pins | GT Pins | BRAM Pins | ILOGICs | OLOGICs |  FFs | LUTMs | DSP48E1s | Clock Net Name |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------+
-| BUFG        | BUFHCE_X1Y10 |   no  |         0 |        0 |       0 |         0 |       0 |       4 |   71 |     0 |        0 | pwm_clk        |
-| BUFG        | BUFHCE_X1Y11 |   no  |         0 |        0 |       0 |         8 |      28 |       0 | 3728 |     0 |        8 | adc_clk        |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------+
+All Modules
++----+----+----+
+|    | X0 | X1 |
++----+----+----+
+| Y1 |  0 |  0 |
+| Y0 |  0 |  0 |
++----+----+----+
 
 
-10. Net wise resources used in clock region X0Y1
-------------------------------------------------
+7. Device Cell Placement Summary for Global Clock g0
+----------------------------------------------------
 
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-| Source Type | BUFHCE Site  | Fixed | MMCM Pins | PLL Pins | GT Pins | BRAM Pins | ILOGICs | OLOGICs |  FFs | LUTMs | DSP48E1s |                      Clock Net Name                      |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-| BUFG        | BUFHCE_X0Y22 |   no  |         0 |        0 |       0 |         0 |       0 |       0 |   49 |     0 |        0 | pwm_clk                                                  |
-| BUFG        | BUFHCE_X0Y20 |   no  |         0 |        0 |       0 |         0 |       0 |       0 |  742 |    70 |        0 | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |
-| BUFG        | BUFHCE_X0Y21 |   no  |         0 |        0 |       0 |        20 |       0 |       0 | 2643 |     1 |        1 | adc_clk                                                  |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
++-----------+-----------------+-------------------+-------------+-------------+---------------+-------------+----------+----------------+----------+---------+
+| Global Id | Driver Type/Pin | Driver Region (D) | Clock       | Period (ns) | Waveform (ns) | Slice Loads | IO Loads | Clocking Loads | GT Loads | Net     |
++-----------+-----------------+-------------------+-------------+-------------+---------------+-------------+----------+----------------+----------+---------+
+| g0        | BUFG/O          | n/a               | pll_adc_clk |       8.000 | {0.000 4.000} |       13349 |        0 |              0 |        0 | adc_clk |
++-----------+-----------------+-------------------+-------------+-------------+---------------+-------------+----------+----------------+----------+---------+
+* Slice Loads column represents load cell count of all cell types other than IO, GT and clock resources
+** IO Loads column represents load cell count of IO types
+*** Clocking Loads column represents load cell count that are clock resources (global clock buffer, MMCM, PLL, etc)
+**** GT Loads column represents load cell count of GT types
 
 
-11. Net wise resources used in clock region X1Y1
-------------------------------------------------
++----+-------+-------+-----------------------+
+|    | X0    | X1    | HORIZONTAL PROG DELAY |
++----+-------+-------+-----------------------+
+| Y1 |  2852 |  3099 |                     0 |
+| Y0 |  3854 |  3544 |                     0 |
++----+-------+-------+-----------------------+
 
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-| Source Type | BUFHCE Site  | Fixed | MMCM Pins | PLL Pins | GT Pins | BRAM Pins | ILOGICs | OLOGICs |  FFs | LUTMs | DSP48E1s |                      Clock Net Name                      |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
-| BUFG        | BUFHCE_X1Y23 |   no  |         0 |        0 |       0 |         0 |       0 |       1 |    0 |     0 |        0 | dac_clk_2p                                               |
-| BUFG        | BUFHCE_X1Y22 |   no  |         0 |        0 |       0 |         0 |       0 |       1 |    0 |     0 |        0 | dac_clk_2x                                               |
-| BUFG        | BUFHCE_X1Y12 |   no  |         0 |        0 |       0 |         0 |       0 |       0 |   19 |     0 |        0 | pwm_clk                                                  |
-| BUFG        | BUFHCE_X1Y19 |   no  |         0 |        0 |       0 |         0 |       0 |      16 |   29 |     0 |        0 | dac_clk_1x                                               |
-| BUFG        | BUFHCE_X1Y20 |   no  |         0 |        0 |       0 |         0 |       0 |       0 |   33 |     0 |        0 | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |
-| BUFG        | BUFHCE_X1Y21 |   no  |         0 |        0 |       0 |        36 |       0 |       0 | 2897 |     0 |        7 | adc_clk                                                  |
-+-------------+--------------+-------+-----------+----------+---------+-----------+---------+---------+------+-------+----------+----------------------------------------------------------+
+
+8. Device Cell Placement Summary for Global Clock g1
+----------------------------------------------------
+
++-----------+-----------------+-------------------+------------+-------------+---------------+-------------+----------+----------------+----------+----------------------------------------------------------+
+| Global Id | Driver Type/Pin | Driver Region (D) | Clock      | Period (ns) | Waveform (ns) | Slice Loads | IO Loads | Clocking Loads | GT Loads | Net                                                      |
++-----------+-----------------+-------------------+------------+-------------+---------------+-------------+----------+----------------+----------+----------------------------------------------------------+
+| g1        | BUFG/O          | n/a               | clk_fpga_3 |       5.000 | {0.000 2.500} |         751 |        0 |              0 |        0 | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |
++-----------+-----------------+-------------------+------------+-------------+---------------+-------------+----------+----------------+----------+----------------------------------------------------------+
+* Slice Loads column represents load cell count of all cell types other than IO, GT and clock resources
+** IO Loads column represents load cell count of IO types
+*** Clocking Loads column represents load cell count that are clock resources (global clock buffer, MMCM, PLL, etc)
+**** GT Loads column represents load cell count of GT types
+
+
++----+------+----+-----------------------+
+|    | X0   | X1 | HORIZONTAL PROG DELAY |
++----+------+----+-----------------------+
+| Y1 |  751 |  0 |                     0 |
+| Y0 |    0 |  0 |                     - |
++----+------+----+-----------------------+
+
+
+9. Device Cell Placement Summary for Global Clock g2
+----------------------------------------------------
+
++-----------+-----------------+-------------------+-------------+-------------+---------------+-------------+----------+----------------+----------+---------+
+| Global Id | Driver Type/Pin | Driver Region (D) | Clock       | Period (ns) | Waveform (ns) | Slice Loads | IO Loads | Clocking Loads | GT Loads | Net     |
++-----------+-----------------+-------------------+-------------+-------------+---------------+-------------+----------+----------------+----------+---------+
+| g2        | BUFG/O          | n/a               | pll_pwm_clk |       4.000 | {0.000 2.000} |         215 |        0 |              0 |        0 | pwm_clk |
++-----------+-----------------+-------------------+-------------+-------------+---------------+-------------+----------+----------------+----------+---------+
+* Slice Loads column represents load cell count of all cell types other than IO, GT and clock resources
+** IO Loads column represents load cell count of IO types
+*** Clocking Loads column represents load cell count that are clock resources (global clock buffer, MMCM, PLL, etc)
+**** GT Loads column represents load cell count of GT types
+
+
++----+----+------+-----------------------+
+|    | X0 | X1   | HORIZONTAL PROG DELAY |
++----+----+------+-----------------------+
+| Y1 |  0 |    0 |                     - |
+| Y0 |  0 |  215 |                     0 |
++----+----+------+-----------------------+
+
+
+10. Device Cell Placement Summary for Global Clock g3
+-----------------------------------------------------
+
++-----------+-----------------+-------------------+----------------+-------------+---------------+-------------+----------+----------------+----------+------------+
+| Global Id | Driver Type/Pin | Driver Region (D) | Clock          | Period (ns) | Waveform (ns) | Slice Loads | IO Loads | Clocking Loads | GT Loads | Net        |
++-----------+-----------------+-------------------+----------------+-------------+---------------+-------------+----------+----------------+----------+------------+
+| g3        | BUFG/O          | n/a               | pll_dac_clk_1x |       8.000 | {0.000 4.000} |          45 |        0 |              0 |        0 | dac_clk_1x |
++-----------+-----------------+-------------------+----------------+-------------+---------------+-------------+----------+----------------+----------+------------+
+* Slice Loads column represents load cell count of all cell types other than IO, GT and clock resources
+** IO Loads column represents load cell count of IO types
+*** Clocking Loads column represents load cell count that are clock resources (global clock buffer, MMCM, PLL, etc)
+**** GT Loads column represents load cell count of GT types
+
+
++----+----+-----+-----------------------+
+|    | X0 | X1  | HORIZONTAL PROG DELAY |
++----+----+-----+-----------------------+
+| Y1 |  0 |  45 |                     0 |
+| Y0 |  0 |   0 |                     - |
++----+----+-----+-----------------------+
+
+
+11. Device Cell Placement Summary for Global Clock g4
+-----------------------------------------------------
+
++-----------+-----------------+-------------------+----------------+-------------+----------------+-------------+----------+----------------+----------+------------+
+| Global Id | Driver Type/Pin | Driver Region (D) | Clock          | Period (ns) | Waveform (ns)  | Slice Loads | IO Loads | Clocking Loads | GT Loads | Net        |
++-----------+-----------------+-------------------+----------------+-------------+----------------+-------------+----------+----------------+----------+------------+
+| g4        | BUFG/O          | n/a               | pll_dac_clk_2p |       4.000 | {-0.500 1.500} |           1 |        0 |              0 |        0 | dac_clk_2p |
++-----------+-----------------+-------------------+----------------+-------------+----------------+-------------+----------+----------------+----------+------------+
+* Slice Loads column represents load cell count of all cell types other than IO, GT and clock resources
+** IO Loads column represents load cell count of IO types
+*** Clocking Loads column represents load cell count that are clock resources (global clock buffer, MMCM, PLL, etc)
+**** GT Loads column represents load cell count of GT types
+
+
++----+----+----+-----------------------+
+|    | X0 | X1 | HORIZONTAL PROG DELAY |
++----+----+----+-----------------------+
+| Y1 |  0 |  1 |                     0 |
+| Y0 |  0 |  0 |                     - |
++----+----+----+-----------------------+
+
+
+12. Device Cell Placement Summary for Global Clock g5
+-----------------------------------------------------
+
++-----------+-----------------+-------------------+----------------+-------------+---------------+-------------+----------+----------------+----------+------------+
+| Global Id | Driver Type/Pin | Driver Region (D) | Clock          | Period (ns) | Waveform (ns) | Slice Loads | IO Loads | Clocking Loads | GT Loads | Net        |
++-----------+-----------------+-------------------+----------------+-------------+---------------+-------------+----------+----------------+----------+------------+
+| g5        | BUFG/O          | n/a               | pll_dac_clk_2x |       4.000 | {0.000 2.000} |           1 |        0 |              0 |        0 | dac_clk_2x |
++-----------+-----------------+-------------------+----------------+-------------+---------------+-------------+----------+----------------+----------+------------+
+* Slice Loads column represents load cell count of all cell types other than IO, GT and clock resources
+** IO Loads column represents load cell count of IO types
+*** Clocking Loads column represents load cell count that are clock resources (global clock buffer, MMCM, PLL, etc)
+**** GT Loads column represents load cell count of GT types
+
+
++----+----+----+-----------------------+
+|    | X0 | X1 | HORIZONTAL PROG DELAY |
++----+----+----+-----------------------+
+| Y1 |  0 |  1 |                     0 |
+| Y0 |  0 |  0 |                     - |
++----+----+----+-----------------------+
+
+
+13. Clock Region Cell Placement per Global Clock: Region X0Y0
+-------------------------------------------------------------
+
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+---------+
+| Global Id | Track | Driver Type/Pin | Constraint | Clock Loads | Non-Clock Loads | FF   | Memory LUTs | RAMB | DSP | GT | MMCM | PLL | Hard IP | Net     |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+---------+
+| g0        | n/a   | BUFG/O          | None       |        3854 |               0 | 3845 |           0 |    5 |   4 |  0 |    0 |   0 |       0 | adc_clk |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+---------+
+* Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+** Non-Clock Loads column represents cell count of non-clock pin loads
+*** Columns FF, LUTRAM, RAMB through 'Hard IP' represents load cell counts
+
+
+14. Clock Region Cell Placement per Global Clock: Region X1Y0
+-------------------------------------------------------------
+
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+---------+
+| Global Id | Track | Driver Type/Pin | Constraint | Clock Loads | Non-Clock Loads | FF   | Memory LUTs | RAMB | DSP | GT | MMCM | PLL | Hard IP | Net     |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+---------+
+| g0        | n/a   | BUFG/O          | None       |        3544 |               0 | 3531 |           0 |    9 |   4 |  0 |    0 |   0 |       0 | adc_clk |
+| g2        | n/a   | BUFG/O          | None       |         215 |               0 |  215 |           0 |    0 |   0 |  0 |    0 |   0 |       0 | pwm_clk |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+---------+
+* Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+** Non-Clock Loads column represents cell count of non-clock pin loads
+*** Columns FF, LUTRAM, RAMB through 'Hard IP' represents load cell counts
+
+
+15. Clock Region Cell Placement per Global Clock: Region X0Y1
+-------------------------------------------------------------
+
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+----------------------------------------------------------+
+| Global Id | Track | Driver Type/Pin | Constraint | Clock Loads | Non-Clock Loads | FF   | Memory LUTs | RAMB | DSP | GT | MMCM | PLL | Hard IP | Net                                                      |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+----------------------------------------------------------+
+| g0        | n/a   | BUFG/O          | None       |        2852 |               0 | 2836 |           0 |    9 |   6 |  0 |    0 |   0 |       0 | adc_clk                                                  |
+| g1        | n/a   | BUFG/O          | None       |         751 |               0 |  698 |          51 |    0 |   0 |  0 |    0 |   0 |       0 | i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3 |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+----------------------------------------------------------+
+* Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+** Non-Clock Loads column represents cell count of non-clock pin loads
+*** Columns FF, LUTRAM, RAMB through 'Hard IP' represents load cell counts
+
+
+16. Clock Region Cell Placement per Global Clock: Region X1Y1
+-------------------------------------------------------------
+
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+------------+
+| Global Id | Track | Driver Type/Pin | Constraint | Clock Loads | Non-Clock Loads | FF   | Memory LUTs | RAMB | DSP | GT | MMCM | PLL | Hard IP | Net        |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+------------+
+| g0        | n/a   | BUFG/O          | None       |        3099 |               0 | 3082 |           0 |   11 |   6 |  0 |    0 |   0 |       0 | adc_clk    |
+| g3        | n/a   | BUFG/O          | None       |          45 |               0 |   29 |           0 |    0 |   0 |  0 |    0 |   0 |       0 | dac_clk_1x |
+| g4        | n/a   | BUFG/O          | None       |           1 |               0 |    0 |           0 |    0 |   0 |  0 |    0 |   0 |       0 | dac_clk_2p |
+| g5        | n/a   | BUFG/O          | None       |           1 |               0 |    0 |           0 |    0 |   0 |  0 |    0 |   0 |       0 | dac_clk_2x |
++-----------+-------+-----------------+------------+-------------+-----------------+------+-------------+------+-----+----+------+-----+---------+------------+
+* Clock Loads column represents cell count of net connects that connect to a clock pin. Internal cell leaf pins are not considered
+** Non-Clock Loads column represents cell count of non-clock pin loads
+*** Columns FF, LUTRAM, RAMB through 'Hard IP' represents load cell counts
 
 
 
 # Location of BUFG Primitives 
-set_property LOC BUFGCTRL_X0Y0 [get_cells bufg_adc_clk]
-set_property LOC BUFGCTRL_X0Y3 [get_cells bufg_dac_clk_1x]
-set_property LOC BUFGCTRL_X0Y4 [get_cells bufg_dac_clk_2p]
-set_property LOC BUFGCTRL_X0Y5 [get_cells bufg_dac_clk_2x]
-set_property LOC BUFGCTRL_X0Y1 [get_cells i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG]
 set_property LOC BUFGCTRL_X0Y2 [get_cells bufg_pwm_clk]
-
-# Location of IO Clock Primitives
-
-# Location of MMCM Clock Primitives
-
-# Location of BUFH Clock Primitives
-
-# Location of BUFR Clock Primitives
-
-# Location of BUFMR Clock Primitives
-
-# Location of PLL Clock Primitives
-set_property LOC PLLE2_ADV_X0Y0 [get_cells pll/pll]
+set_property LOC BUFGCTRL_X0Y1 [get_cells i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG]
+set_property LOC BUFGCTRL_X0Y5 [get_cells bufg_dac_clk_2x]
+set_property LOC BUFGCTRL_X0Y4 [get_cells bufg_dac_clk_2p]
+set_property LOC BUFGCTRL_X0Y3 [get_cells bufg_dac_clk_1x]
+set_property LOC BUFGCTRL_X0Y0 [get_cells bufg_adc_clk]
 
 # Location of IO Primitives which is load of clock spine
 
@@ -189,25 +326,18 @@ set_property LOC PLLE2_ADV_X0Y0 [get_cells pll/pll]
 set_property LOC IOB_X0Y25 [get_ports adc_clk_n_i]
 set_property LOC IOB_X0Y26 [get_ports adc_clk_p_i]
 
-# Clock net "adc_clk" driven by instance "bufg_adc_clk" located at site "BUFGCTRL_X0Y0"
+# Clock net "pwm_clk" driven by instance "bufg_pwm_clk" located at site "BUFGCTRL_X0Y2"
 #startgroup
-create_pblock {CLKAG_adc_clk}
-add_cells_to_pblock [get_pblocks  {CLKAG_adc_clk}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="adc_clk"}]]]
-resize_pblock [get_pblocks {CLKAG_adc_clk}] -add {CLOCKREGION_X0Y0:CLOCKREGION_X0Y0 CLOCKREGION_X0Y1:CLOCKREGION_X0Y1 CLOCKREGION_X1Y0:CLOCKREGION_X1Y0 CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
+create_pblock {CLKAG_pwm_clk}
+add_cells_to_pblock [get_pblocks  {CLKAG_pwm_clk}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="pwm_clk"}]]]
+resize_pblock [get_pblocks {CLKAG_pwm_clk}] -add {CLOCKREGION_X1Y0:CLOCKREGION_X1Y0}
 #endgroup
 
-# Clock net "dac_clk_1x" driven by instance "bufg_dac_clk_1x" located at site "BUFGCTRL_X0Y3"
+# Clock net "i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3" driven by instance "i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG" located at site "BUFGCTRL_X0Y1"
 #startgroup
-create_pblock {CLKAG_dac_clk_1x}
-add_cells_to_pblock [get_pblocks  {CLKAG_dac_clk_1x}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="dac_clk_1x"}]]]
-resize_pblock [get_pblocks {CLKAG_dac_clk_1x}] -add {CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
-#endgroup
-
-# Clock net "dac_clk_2p" driven by instance "bufg_dac_clk_2p" located at site "BUFGCTRL_X0Y4"
-#startgroup
-create_pblock {CLKAG_dac_clk_2p}
-add_cells_to_pblock [get_pblocks  {CLKAG_dac_clk_2p}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="dac_clk_2p"}]]]
-resize_pblock [get_pblocks {CLKAG_dac_clk_2p}] -add {CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
+create_pblock {CLKAG_i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3}
+add_cells_to_pblock [get_pblocks  {CLKAG_i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3"}]]]
+resize_pblock [get_pblocks {CLKAG_i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3}] -add {CLOCKREGION_X0Y1:CLOCKREGION_X0Y1}
 #endgroup
 
 # Clock net "dac_clk_2x" driven by instance "bufg_dac_clk_2x" located at site "BUFGCTRL_X0Y5"
@@ -217,23 +347,23 @@ add_cells_to_pblock [get_pblocks  {CLKAG_dac_clk_2x}] [get_cells -filter { PRIMI
 resize_pblock [get_pblocks {CLKAG_dac_clk_2x}] -add {CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
 #endgroup
 
-# Clock net "i_hk/dna_clk" driven by instance "i_hk/dna_clk_reg" located at site "SLICE_X17Y43"
+# Clock net "dac_clk_2p" driven by instance "bufg_dac_clk_2p" located at site "BUFGCTRL_X0Y4"
 #startgroup
-create_pblock {CLKAG_i_hk/dna_clk}
-add_cells_to_pblock [get_pblocks  {CLKAG_i_hk/dna_clk}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="i_hk/dna_clk"}]]]
-resize_pblock [get_pblocks {CLKAG_i_hk/dna_clk}] -add {CLOCKREGION_X0Y0:CLOCKREGION_X0Y0}
+create_pblock {CLKAG_dac_clk_2p}
+add_cells_to_pblock [get_pblocks  {CLKAG_dac_clk_2p}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="dac_clk_2p"}]]]
+resize_pblock [get_pblocks {CLKAG_dac_clk_2p}] -add {CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
 #endgroup
 
-# Clock net "i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3" driven by instance "i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG" located at site "BUFGCTRL_X0Y1"
+# Clock net "dac_clk_1x" driven by instance "bufg_dac_clk_1x" located at site "BUFGCTRL_X0Y3"
 #startgroup
-create_pblock {CLKAG_i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3}
-add_cells_to_pblock [get_pblocks  {CLKAG_i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3"}]]]
-resize_pblock [get_pblocks {CLKAG_i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK3}] -add {CLOCKREGION_X0Y0:CLOCKREGION_X0Y0 CLOCKREGION_X0Y1:CLOCKREGION_X0Y1 CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
+create_pblock {CLKAG_dac_clk_1x}
+add_cells_to_pblock [get_pblocks  {CLKAG_dac_clk_1x}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="dac_clk_1x"}]]]
+resize_pblock [get_pblocks {CLKAG_dac_clk_1x}] -add {CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
 #endgroup
 
-# Clock net "pwm_clk" driven by instance "bufg_pwm_clk" located at site "BUFGCTRL_X0Y2"
+# Clock net "adc_clk" driven by instance "bufg_adc_clk" located at site "BUFGCTRL_X0Y0"
 #startgroup
-create_pblock {CLKAG_pwm_clk}
-add_cells_to_pblock [get_pblocks  {CLKAG_pwm_clk}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="pwm_clk"}]]]
-resize_pblock [get_pblocks {CLKAG_pwm_clk}] -add {CLOCKREGION_X0Y0:CLOCKREGION_X0Y0 CLOCKREGION_X0Y1:CLOCKREGION_X0Y1 CLOCKREGION_X1Y0:CLOCKREGION_X1Y0 CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
+create_pblock {CLKAG_adc_clk}
+add_cells_to_pblock [get_pblocks  {CLKAG_adc_clk}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="adc_clk"}]]]
+resize_pblock [get_pblocks {CLKAG_adc_clk}] -add {CLOCKREGION_X0Y0:CLOCKREGION_X0Y0 CLOCKREGION_X0Y1:CLOCKREGION_X0Y1 CLOCKREGION_X1Y0:CLOCKREGION_X1Y0 CLOCKREGION_X1Y1:CLOCKREGION_X1Y1}
 #endgroup

--- a/pyrpl/fpga/out/post_imp_drc.rpt
+++ b/pyrpl/fpga/out/post_imp_drc.rpt
@@ -1,10 +1,14 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-------------------------------------------------------------------------------------
-| Tool Version : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date         : Fri Mar 17 14:14:12 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:34:14 2025
 | Host         : fontana running 64-bit major release  (build 9200)
-| Command      : report_drc
-------------------------------------------------------------------------------------
+| Command      : report_drc -file out/post_imp_drc.rpt
+| Design       : red_pitaya_top
+| Device       : xc7z010clg400-1
+| Speed File   : -1
+| Design State : Fully Routed
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Report DRC
 
@@ -19,31 +23,26 @@ Table of Contents
           Floorplan: design_1
       Design limits: <entire design considered>
            Ruledeck: default
-             Max violations: <unlimited>
-             Violations found: 174
+             Max checks: <unlimited>
+             Checks found: 228
++----------+----------+----------------------------+--------+
+| Rule     | Severity | Description                | Checks |
++----------+----------+----------------------------+--------+
+| DPIP-1   | Warning  | Input pipelining           | 72     |
+| DPOP-1   | Warning  | PREG Output pipelining     | 38     |
+| DPOP-2   | Warning  | MREG Output pipelining     | 43     |
+| PDRC-132 | Warning  | SLICE_PairEqSame_A6A5_WARN | 2      |
+| PDRC-134 | Warning  | SLICE_PairEqSame_B6B5_WARN | 7      |
+| PDRC-136 | Warning  | SLICE_PairEqSame_C6C5_WARN | 17     |
+| PDRC-138 | Warning  | SLICE_PairEqSame_D6D5_WARN | 26     |
+| PDRC-140 | Warning  | SLICE_PairEqSame_A6A5_WARN | 1      |
+| PDRC-142 | Warning  | SLICE_PairEqSame_B6B5_WARN | 7      |
+| PDRC-144 | Warning  | SLICE_PairEqSame_C6C5_WARN | 8      |
+| PDRC-146 | Warning  | SLICE_PairEqSame_D6D5_WARN | 7      |
++----------+----------+----------------------------+--------+
 
 2. REPORT DETAILS
 -----------------
-BUFC-1#1 Warning
-Input Buffer Connections  
-Input buffer daisy_n_i[0]_IBUF_inst has no loads. An input buffer must drive an internal load.
-Related violations: <none>
-
-BUFC-1#2 Warning
-Input Buffer Connections  
-Input buffer daisy_n_i[1]_IBUF_inst has no loads. An input buffer must drive an internal load.
-Related violations: <none>
-
-BUFC-1#3 Warning
-Input Buffer Connections  
-Input buffer daisy_p_i[0]_IBUF_inst has no loads. An input buffer must drive an internal load.
-Related violations: <none>
-
-BUFC-1#4 Warning
-Input Buffer Connections  
-Input buffer daisy_p_i[1]_IBUF_inst has no loads. An input buffer must drive an internal load.
-Related violations: <none>
-
 DPIP-1#1 Warning
 Input pipelining  
 DSP i_asg/ch[0]/dac_mult_reg input i_asg/ch[0]/dac_mult_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
@@ -56,407 +55,442 @@ Related violations: <none>
 
 DPIP-1#3 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 input i_dsp/genblk4[4].iir/p_ay1_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk2[0].i_pid/ki_mult_reg input i_dsp/genblk2[0].i_pid/ki_mult_reg/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#4 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 input i_dsp/genblk4[4].iir/p_ay1_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk2[0].i_pid/kp_mult0 input i_dsp/genblk2[0].i_pid/kp_mult0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#5 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 input i_dsp/genblk4[4].iir/p_ay1_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk2[1].i_pid/ki_mult_reg input i_dsp/genblk2[1].i_pid/ki_mult_reg/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#6 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 input i_dsp/genblk4[4].iir/p_ay1_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk2[1].i_pid/kp_mult0 input i_dsp/genblk2[1].i_pid/kp_mult0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#7 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 input i_dsp/genblk4[4].iir/p_ay1_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk2[2].i_pid/ki_mult_reg input i_dsp/genblk2[2].i_pid/ki_mult_reg/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#8 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 input i_dsp/genblk4[4].iir/p_ay1_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk2[2].i_pid/kp_mult0 input i_dsp/genblk2[2].i_pid/kp_mult0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#9 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__2 input i_dsp/genblk4[4].iir/p_ay1_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 input i_dsp/genblk4[4].iir/p_ay1_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#10 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 input i_dsp/genblk4[4].iir/p_ay2_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 input i_dsp/genblk4[4].iir/p_ay1_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#11 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 input i_dsp/genblk4[4].iir/p_ay2_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 input i_dsp/genblk4[4].iir/p_ay1_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#12 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 input i_dsp/genblk4[4].iir/p_ay2_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 input i_dsp/genblk4[4].iir/p_ay1_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#13 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 input i_dsp/genblk4[4].iir/p_ay2_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 input i_dsp/genblk4[4].iir/p_ay1_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#14 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 input i_dsp/genblk4[4].iir/p_ay2_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 input i_dsp/genblk4[4].iir/p_ay1_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#15 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 input i_dsp/genblk4[4].iir/p_ay2_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__2 input i_dsp/genblk4[4].iir/p_ay1_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#16 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__2 input i_dsp/genblk4[4].iir/p_ay2_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 input i_dsp/genblk4[4].iir/p_ay2_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#17 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 input i_dsp/genblk4[4].iir/p_bx0_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 input i_dsp/genblk4[4].iir/p_ay2_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#18 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 input i_dsp/genblk4[4].iir/p_bx0_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 input i_dsp/genblk4[4].iir/p_ay2_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#19 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 input i_dsp/genblk4[4].iir/p_bx0_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 input i_dsp/genblk4[4].iir/p_ay2_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#20 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 input i_dsp/genblk4[4].iir/p_bx0_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 input i_dsp/genblk4[4].iir/p_ay2_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#21 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 input i_dsp/genblk4[4].iir/p_bx0_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 input i_dsp/genblk4[4].iir/p_ay2_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#22 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 input i_dsp/genblk4[4].iir/p_bx0_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__2 input i_dsp/genblk4[4].iir/p_ay2_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#23 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__2 input i_dsp/genblk4[4].iir/p_bx0_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 input i_dsp/genblk4[4].iir/p_bx0_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#24 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 input i_dsp/genblk4[4].iir/p_bx1_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 input i_dsp/genblk4[4].iir/p_bx0_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#25 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 input i_dsp/genblk4[4].iir/p_bx1_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 input i_dsp/genblk4[4].iir/p_bx0_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#26 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 input i_dsp/genblk4[4].iir/p_bx1_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 input i_dsp/genblk4[4].iir/p_bx0_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#27 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 input i_dsp/genblk4[4].iir/p_bx1_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 input i_dsp/genblk4[4].iir/p_bx0_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#28 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 input i_dsp/genblk4[4].iir/p_bx1_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 input i_dsp/genblk4[4].iir/p_bx0_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#29 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 input i_dsp/genblk4[4].iir/p_bx1_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__2 input i_dsp/genblk4[4].iir/p_bx0_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#30 Warning
 Input pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__2 input i_dsp/genblk4[4].iir/p_bx1_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 input i_dsp/genblk4[4].iir/p_bx1_module/product0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#31 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/demodulator/product1_reg input i_dsp/genblk5[5].iq/demodulator/product1_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 input i_dsp/genblk4[4].iir/p_bx1_module/product0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#32 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/demodulator/product2_reg input i_dsp/genblk5[5].iq/demodulator/product2_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 input i_dsp/genblk4[4].iir/p_bx1_module/product0__0/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#33 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 input i_dsp/genblk4[4].iir/p_bx1_module/product0__0/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#34 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 input i_dsp/genblk4[4].iir/p_bx1_module/product0__1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#35 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 input i_dsp/genblk4[4].iir/p_bx1_module/product0__1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#36 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__2 input i_dsp/genblk4[4].iir/p_bx1_module/product0__2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#37 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/demodulator/product1_reg input i_dsp/genblk5[5].iq/demodulator/product1_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#38 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/demodulator/product2_reg input i_dsp/genblk5[5].iq/demodulator/product2_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#39 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/secondproduct1 input i_dsp/genblk5[5].iq/modulator/secondproduct1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#40 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/secondproduct1 input i_dsp/genblk5[5].iq/modulator/secondproduct1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#41 Warning
 Input pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/secondproduct2 input i_dsp/genblk5[5].iq/modulator/secondproduct2/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#42 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/demodulator/product1_reg input i_dsp/genblk5[6].iq/demodulator/product1_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#43 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/demodulator/product2_reg input i_dsp/genblk5[6].iq/demodulator/product2_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#44 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#45 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/secondproduct1 input i_dsp/genblk5[5].iq/modulator/secondproduct1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#46 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/secondproduct1 input i_dsp/genblk5[5].iq/modulator/secondproduct1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#47 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[5].iq/modulator/secondproduct2 input i_dsp/genblk5[5].iq/modulator/secondproduct2/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#48 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/demodulator/product1_reg input i_dsp/genblk5[6].iq/demodulator/product1_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#49 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/demodulator/product2_reg input i_dsp/genblk5[6].iq/demodulator/product2_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#50 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 input i_dsp/genblk5[6].iq/modulator/secondproduct1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#51 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 input i_dsp/genblk5[6].iq/modulator/secondproduct1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#52 Warning
 Input pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct2 input i_dsp/genblk5[6].iq/modulator/secondproduct2/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#53 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg input i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product input i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#54 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg input i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#55 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product input i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#56 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 input i_dsp/genblk5[6].iq/modulator/secondproduct1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#57 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 input i_dsp/genblk5[6].iq/modulator/secondproduct1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#58 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct2 input i_dsp/genblk5[6].iq/modulator/secondproduct2/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#59 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg input i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#60 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg input i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#61 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#62 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#63 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 input i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#64 Warning
 Input pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 input i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product input i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPIP-1#65 Warning
 Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#66 Warning
+Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#67 Warning
+Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#68 Warning
+Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product input i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#69 Warning
+Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 input i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#70 Warning
+Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 input i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#71 Warning
+Input pipelining  
 DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2 input i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
+Related violations: <none>
+
+DPIP-1#72 Warning
+Input pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2 input i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2/B[17:0] is not pipelined. Pipelining DSP48 input will improve performance.
 Related violations: <none>
 
 DPOP-1#1 Warning
 PREG Output pipelining  
-DSP i_asg/ch[0]/dac_mult_reg output i_asg/ch[0]/dac_mult_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 output i_dsp/genblk4[4].iir/p_ay1_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#2 Warning
 PREG Output pipelining  
-DSP i_asg/ch[1]/dac_mult_reg output i_asg/ch[1]/dac_mult_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 output i_dsp/genblk4[4].iir/p_ay1_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#3 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 output i_dsp/genblk4[4].iir/p_ay1_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 output i_dsp/genblk4[4].iir/p_ay1_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#4 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 output i_dsp/genblk4[4].iir/p_ay1_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__2 output i_dsp/genblk4[4].iir/p_ay1_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#5 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 output i_dsp/genblk4[4].iir/p_ay1_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 output i_dsp/genblk4[4].iir/p_ay2_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#6 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__2 output i_dsp/genblk4[4].iir/p_ay1_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 output i_dsp/genblk4[4].iir/p_ay2_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#7 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 output i_dsp/genblk4[4].iir/p_ay2_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 output i_dsp/genblk4[4].iir/p_ay2_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#8 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 output i_dsp/genblk4[4].iir/p_ay2_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__2 output i_dsp/genblk4[4].iir/p_ay2_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#9 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 output i_dsp/genblk4[4].iir/p_ay2_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 output i_dsp/genblk4[4].iir/p_bx0_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#10 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__2 output i_dsp/genblk4[4].iir/p_ay2_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 output i_dsp/genblk4[4].iir/p_bx0_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#11 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 output i_dsp/genblk4[4].iir/p_bx0_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 output i_dsp/genblk4[4].iir/p_bx0_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#12 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 output i_dsp/genblk4[4].iir/p_bx0_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__2 output i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#13 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 output i_dsp/genblk4[4].iir/p_bx0_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 output i_dsp/genblk4[4].iir/p_bx1_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#14 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__2 output i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 output i_dsp/genblk4[4].iir/p_bx1_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#15 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 output i_dsp/genblk4[4].iir/p_bx1_module/product0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 output i_dsp/genblk4[4].iir/p_bx1_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#16 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 output i_dsp/genblk4[4].iir/p_bx1_module/product0__0/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__2 output i_dsp/genblk4[4].iir/p_bx1_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#17 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 output i_dsp/genblk4[4].iir/p_bx1_module/product0__1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[5].iq/demodulator/product1_reg output i_dsp/genblk5[5].iq/demodulator/product1_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#18 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__2 output i_dsp/genblk4[4].iir/p_bx1_module/product0__2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[5].iq/demodulator/product2_reg output i_dsp/genblk5[5].iq/demodulator/product2_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#19 Warning
@@ -486,468 +520,667 @@ Related violations: <none>
 
 DPOP-1#24 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product output i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/demodulator/product1_reg output i_dsp/genblk5[6].iq/demodulator/product1_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#25 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product output i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/demodulator/product2_reg output i_dsp/genblk5[6].iq/demodulator/product2_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#26 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product output i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product output i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#27 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 output i_dsp/genblk5[6].iq/modulator/secondproduct1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product output i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#28 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct2 output i_dsp/genblk5[6].iq/modulator/secondproduct2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product output i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#29 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product output i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 output i_dsp/genblk5[6].iq/modulator/secondproduct1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#30 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product output i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct2 output i_dsp/genblk5[6].iq/modulator/secondproduct2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#31 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product output i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg output i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#32 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product output i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg output i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#33 Warning
 PREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 output i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product output i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-1#34 Warning
+PREG Output pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product output i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+Related violations: <none>
+
+DPOP-1#35 Warning
+PREG Output pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product output i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+Related violations: <none>
+
+DPOP-1#36 Warning
+PREG Output pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product output i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+Related violations: <none>
+
+DPOP-1#37 Warning
+PREG Output pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 output i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
+Related violations: <none>
+
+DPOP-1#38 Warning
 PREG Output pipelining  
 DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2 output i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2/P[47:0] is not pipelined (PREG=0). Pipelining the DSP48 output will improve performance and often saves power so it is suggested whenever possible to fully pipeline this function.  If this DSP48 function was inferred, it is suggested to describe an additional register stage after this function.  If the DSP48 was instantiated in the design, it is suggested to set the PREG attribute to 1.
 Related violations: <none>
 
 DPOP-2#1 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk2[0].i_pid/ki_mult_reg multiplier stage i_dsp/genblk2[0].i_pid/ki_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_asg/ch[0]/dac_mult_reg multiplier stage i_asg/ch[0]/dac_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#2 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk2[1].i_pid/ki_mult_reg multiplier stage i_dsp/genblk2[1].i_pid/ki_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_asg/ch[1]/dac_mult_reg multiplier stage i_asg/ch[1]/dac_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#3 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk2[2].i_pid/ki_mult_reg multiplier stage i_dsp/genblk2[2].i_pid/ki_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk2[0].i_pid/ki_mult_reg multiplier stage i_dsp/genblk2[0].i_pid/ki_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#4 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk2[1].i_pid/ki_mult_reg multiplier stage i_dsp/genblk2[1].i_pid/ki_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#5 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk2[2].i_pid/ki_mult_reg multiplier stage i_dsp/genblk2[2].i_pid/ki_mult_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#6 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#7 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#8 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#9 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay1_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_ay1_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#10 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#11 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#12 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#13 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_ay2_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_ay2_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#14 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#15 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#16 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#17 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx0_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#18 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#19 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__0 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0__0/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#20 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/demodulator/product1_reg multiplier stage i_dsp/genblk5[5].iq/demodulator/product1_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__1 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0__1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#21 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/demodulator/product2_reg multiplier stage i_dsp/genblk5[5].iq/demodulator/product2_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk4[4].iir/p_bx1_module/product0__2 multiplier stage i_dsp/genblk4[4].iir/p_bx1_module/product0__2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#22 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product multiplier stage i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/demodulator/product1_reg multiplier stage i_dsp/genblk5[5].iq/demodulator/product1_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#23 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product multiplier stage i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/demodulator/product2_reg multiplier stage i_dsp/genblk5[5].iq/demodulator/product2_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#24 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product multiplier stage i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product multiplier stage i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#25 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/secondproduct1 multiplier stage i_dsp/genblk5[5].iq/modulator/secondproduct1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product multiplier stage i_dsp/genblk5[5].iq/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#26 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[5].iq/modulator/secondproduct2 multiplier stage i_dsp/genblk5[5].iq/modulator/secondproduct2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product multiplier stage i_dsp/genblk5[5].iq/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#27 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/demodulator/product1_reg multiplier stage i_dsp/genblk5[6].iq/demodulator/product1_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/modulator/secondproduct1 multiplier stage i_dsp/genblk5[5].iq/modulator/secondproduct1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#28 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/demodulator/product2_reg multiplier stage i_dsp/genblk5[6].iq/demodulator/product2_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[5].iq/modulator/secondproduct2 multiplier stage i_dsp/genblk5[5].iq/modulator/secondproduct2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#29 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product multiplier stage i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/demodulator/product1_reg multiplier stage i_dsp/genblk5[6].iq/demodulator/product1_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#30 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product multiplier stage i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/demodulator/product2_reg multiplier stage i_dsp/genblk5[6].iq/demodulator/product2_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#31 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product multiplier stage i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product multiplier stage i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#32 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 multiplier stage i_dsp/genblk5[6].iq/modulator/secondproduct1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product multiplier stage i_dsp/genblk5[6].iq/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#33 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk5[6].iq/modulator/secondproduct2 multiplier stage i_dsp/genblk5[6].iq/modulator/secondproduct2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product multiplier stage i_dsp/genblk5[6].iq/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#34 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg multiplier stage i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct1 multiplier stage i_dsp/genblk5[6].iq/modulator/secondproduct1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#35 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg multiplier stage i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk5[6].iq/modulator/secondproduct2 multiplier stage i_dsp/genblk5[6].iq/modulator/secondproduct2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#36 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg multiplier stage i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#37 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg multiplier stage i_dsp/genblk6[7].iq_2_outputs/demodulator/product2_reg/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#38 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[0]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#39 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/firstproduct_saturation[1]/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#40 Warning
 MREG Output pipelining  
-DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/i0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
 DPOP-2#41 Warning
 MREG Output pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/q0_product_and_sat/product/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+Related violations: <none>
+
+DPOP-2#42 Warning
+MREG Output pipelining  
+DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1 multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
+Related violations: <none>
+
+DPOP-2#43 Warning
+MREG Output pipelining  
 DSP i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2 multiplier stage i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct2/P[47:0] is not pipelined (MREG=0). Pipelining the multiplier function will improve performance and will save significant power so it is suggested whenever possible to fully pipeline this function.  If this multiplier was inferred, it is suggested to describe an additional register stage after this function.  If there is no registered adder/accumulator following the multiply function, two pipeline stages are suggested to allow both the MREG and PREG registers to be used.  If the DSP48 was instantiated in the design, it is suggested to set both the MREG and PREG attributes to 1 when performing multiply functions.
 Related violations: <none>
 
-PLIO-7#1 Warning
-Placement Constraints Check for IO constraints  
-An IO Bus FIXED_IO_mio[53:0] with more than one IO standard is found. Components associated with this bus are: LVCMOS33 (FIXED_IO_mio[15], FIXED_IO_mio[14], FIXED_IO_mio[13], FIXED_IO_mio[12], FIXED_IO_mio[11], FIXED_IO_mio[10], FIXED_IO_mio[9], FIXED_IO_mio[8], FIXED_IO_mio[7], FIXED_IO_mio[6], FIXED_IO_mio[5], FIXED_IO_mio[4], FIXED_IO_mio[3], FIXED_IO_mio[2], FIXED_IO_mio[1] (the first 15 of 16 listed)); LVCMOS25 (FIXED_IO_mio[53], FIXED_IO_mio[52], FIXED_IO_mio[51], FIXED_IO_mio[50], FIXED_IO_mio[49], FIXED_IO_mio[48], FIXED_IO_mio[47], FIXED_IO_mio[46], FIXED_IO_mio[45], FIXED_IO_mio[44], FIXED_IO_mio[43], FIXED_IO_mio[42], FIXED_IO_mio[41], FIXED_IO_mio[40], FIXED_IO_mio[39] (the first 15 of 38 listed)); 
+PDRC-132#1 Warning
+SLICE_PairEqSame_A6A5_WARN  
+Luts A6LUT and A5LUT in use in site SLICE_X19Y75 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-RTSTAT-10#1 Warning
-No routable loads  
-4 net(s) have no routable loads. The problem bus(es) and/or net(s) are daisy_n_i[0]_IBUF, daisy_n_i[1]_IBUF, daisy_p_i[0]_IBUF, daisy_p_i[1]_IBUF.
+PDRC-132#2 Warning
+SLICE_PairEqSame_A6A5_WARN  
+Luts A6LUT and A5LUT in use in site SLICE_X23Y62 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#1 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[10]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#1 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X17Y29 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#2 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[11]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#2 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X19Y75 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#3 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[12]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#3 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X23Y62 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#4 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[13]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#4 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X36Y12 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#5 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[14]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#5 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X41Y35 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#6 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[15]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#6 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X43Y8 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#7 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[2]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-134#7 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X7Y46 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#8 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[3]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#1 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X11Y93 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#9 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[4]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#2 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X14Y91 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#10 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[5]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#3 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X15Y18 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#11 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[6]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#4 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X15Y69 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#12 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[7]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#5 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X17Y29 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#13 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[8]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#6 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X17Y90 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#14 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_a_i[9]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_a_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 210)
+PDRC-136#7 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X19Y75 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#15 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[10]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#8 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X1Y73 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#16 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[11]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#9 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X2Y69 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#17 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[12]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#10 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X2Y73 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#18 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[13]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#11 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X33Y73 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#19 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[14]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#12 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X35Y43 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#20 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[15]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#13 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X36Y12 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#21 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[2]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#14 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X36Y44 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#22 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[3]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#15 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X43Y8 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#23 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[4]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#16 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X5Y75 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#24 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[5]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-136#17 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X7Y92 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#25 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[6]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-138#1 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X11Y93 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#26 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[7]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-138#2 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X14Y91 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#27 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[8]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-138#3 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X14Y99 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
-XDCH-2#28 Warning
-Same min and max delay values on IO port  
-The same input delay of 3.400 ns has been defined on port 'adc_dat_b_i[9]' relative to clock adc_clk for both max and min. Make sure this reflects the design intent.
-set_input_delay -clock adc_clk 3.400 [get_ports {adc_dat_b_i[*]}]
-c:/Users/michael.croquette/Documents/GitHub/pyrpl/pyrpl/fpga/sdc/red_pitaya.xdc (Line: 211)
+PDRC-138#4 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X15Y18 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#5 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X17Y29 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#6 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X17Y90 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#7 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X18Y98 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#8 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X19Y75 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#9 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X21Y86 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#10 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X26Y18 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#11 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X2Y27 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#12 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X2Y69 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#13 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X2Y87 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#14 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X35Y43 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#15 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X36Y12 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#16 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X36Y67 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#17 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X37Y85 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#18 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X37Y95 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#19 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X3Y31 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#20 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X41Y35 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#21 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X41Y67 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#22 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X43Y8 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#23 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X5Y30 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#24 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X5Y75 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#25 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X5Y90 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-138#26 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X7Y92 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-140#1 Warning
+SLICE_PairEqSame_A6A5_WARN  
+Luts A6LUT and A5LUT in use in site SLICE_X8Y77 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#1 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X20Y30 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#2 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X28Y75 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#3 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X30Y95 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#4 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X32Y96 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#5 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X34Y13 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#6 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X34Y71 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-142#7 Warning
+SLICE_PairEqSame_B6B5_WARN  
+Luts B6LUT and B5LUT in use in site SLICE_X42Y39 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#1 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X0Y68 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#2 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X28Y75 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#3 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X30Y95 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#4 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X34Y13 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#5 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X34Y49 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#6 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X42Y39 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#7 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X4Y69 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-144#8 Warning
+SLICE_PairEqSame_C6C5_WARN  
+Luts C6LUT and C5LUT in use in site SLICE_X6Y51 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#1 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X0Y68 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#2 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X10Y67 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#3 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X24Y14 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#4 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X32Y58 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#5 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X34Y49 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#6 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X42Y39 with different equations without A6 pin connected to Global Logic High.
+Related violations: <none>
+
+PDRC-146#7 Warning
+SLICE_PairEqSame_D6D5_WARN  
+Luts D6LUT and D5LUT in use in site SLICE_X6Y51 with different equations without A6 pin connected to Global Logic High.
 Related violations: <none>
 
 

--- a/pyrpl/fpga/out/post_place_timing_summary.rpt
+++ b/pyrpl/fpga/out/post_place_timing_summary.rpt
@@ -1,13 +1,14 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-------------------------------------------------------------------------------------
-| Tool Version : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date         : Fri Mar 17 14:11:47 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:30:24 2025
 | Host         : fontana running 64-bit major release  (build 9200)
 | Command      : report_timing_summary -file out/post_place_timing_summary.rpt
 | Design       : red_pitaya_top
 | Device       : 7z010-clg400
-| Speed File   : -1  PRODUCTION 1.11 2014-09-11
-------------------------------------------------------------------------------------
+| Speed File   : -1  PRODUCTION 1.12 2019-11-22
+| Design State : Physopt postPlace
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Timing Summary Report
 
@@ -23,7 +24,10 @@ Timing Summary Report
   Enable Preset / Clear Arcs                 :  No
   Disable Flight Delays                      :  No
   Ignore I/O Paths                           :  No
-  Timing Early Launch at Borrowing Latches   :  false
+  Timing Early Launch at Borrowing Latches   :  No
+  Borrow Time for Max Delay Exceptions       :  Yes
+  Merge Timing Exceptions                    :  Yes
+  Inter-SLR Compensation                     :  Conservative
 
   Corner  Analyze    Analyze    
   Name    Max Paths  Min Paths  
@@ -32,55 +36,63 @@ Timing Summary Report
   Fast    Yes        Yes        
 
 
+------------------------------------------------------------------------------------------------
+| Report Methodology
+| ------------------
+------------------------------------------------------------------------------------------------
+
+No report available as report_methodology has not been run prior. Run report_methodology on the current design for the summary of methodology violations.
+
+
 
 check_timing report
 
 Table of Contents
 -----------------
-1. checking no_clock
-2. checking constant_clock
-3. checking pulse_width_clock
-4. checking unconstrained_internal_endpoints
-5. checking no_input_delay
-6. checking no_output_delay
-7. checking multiple_clock
-8. checking generated_clocks
-9. checking loops
-10. checking partial_input_delay
-11. checking partial_output_delay
-12. checking latch_loops
+1. checking no_clock (1)
+2. checking constant_clock (0)
+3. checking pulse_width_clock (0)
+4. checking unconstrained_internal_endpoints (2)
+5. checking no_input_delay (16)
+6. checking no_output_delay (46)
+7. checking multiple_clock (0)
+8. checking generated_clocks (0)
+9. checking loops (0)
+10. checking partial_input_delay (0)
+11. checking partial_output_delay (0)
+12. checking latch_loops (0)
 
-1. checking no_clock
---------------------
- There is 1 register/latch pin with no clock driven by root clock pin: i_hk/dna_clk_reg/C (HIGH)
+1. checking no_clock (1)
+------------------------
+ There is 1 register/latch pin with no clock driven by root clock pin: i_hk/dna_clk_reg/Q (HIGH)
 
 
-2. checking constant_clock
---------------------------
+2. checking constant_clock (0)
+------------------------------
  There are 0 register/latch pins with constant_clock.
 
 
-3. checking pulse_width_clock
------------------------------
+3. checking pulse_width_clock (0)
+---------------------------------
  There are 0 register/latch pins which need pulse_width check
 
 
-4. checking unconstrained_internal_endpoints
---------------------------------------------
+4. checking unconstrained_internal_endpoints (2)
+------------------------------------------------
  There are 2 pins that are not constrained for maximum delay. (HIGH)
 
  There are 0 pins that are not constrained for maximum delay due to constant clock.
 
 
-5. checking no_input_delay
---------------------------
+5. checking no_input_delay (16)
+-------------------------------
  There are 16 input ports with no input delay specified. (HIGH)
 
  There are 0 input ports with no input delay but user has a false path constraint.
 
 
-6. checking no_output_delay
----------------------------
+6. checking no_output_delay (46)
+--------------------------------
  There are 46 ports with no output delay specified. (HIGH)
 
  There are 0 ports with no output delay but user has a false path constraint
@@ -88,33 +100,33 @@ Table of Contents
  There are 0 ports with no output delay but with a timing clock defined on it or propagating through it
 
 
-7. checking multiple_clock
---------------------------
+7. checking multiple_clock (0)
+------------------------------
  There are 0 register/latch pins with multiple clocks.
 
 
-8. checking generated_clocks
-----------------------------
+8. checking generated_clocks (0)
+--------------------------------
  There are 0 generated clocks that are not connected to a clock source.
 
 
-9. checking loops
------------------
+9. checking loops (0)
+---------------------
  There are 0 combinational loops in the design.
 
 
-10. checking partial_input_delay
---------------------------------
+10. checking partial_input_delay (0)
+------------------------------------
  There are 0 input ports with partial input delay specified.
 
 
-11. checking partial_output_delay
----------------------------------
+11. checking partial_output_delay (0)
+-------------------------------------
  There are 0 ports with partial output delay specified.
 
 
-12. checking latch_loops
-------------------------
+12. checking latch_loops (0)
+----------------------------
  There are 0 combinational latch loops in the design through latch input
 
 
@@ -126,7 +138,7 @@ Table of Contents
 
     WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints     WPWS(ns)     TPWS(ns)  TPWS Failing Endpoints  TPWS Total Endpoints  
     -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
-     -5.778    -7202.360                   6232                36512       -2.537      -78.360                     98                36512        1.000        0.000                       0                 14501  
+     -4.865    -7220.550                   5971                36492       -1.762      -60.501                    132                36492        1.000        0.000                       0                 14396  
 
 
 Timing constraints are not met.
@@ -162,12 +174,12 @@ Clock                 WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total End
 -----                 -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
 adc_clk                                                                                                                                                             2.000        0.000                       0                     1  
   clk_fb                                                                                                                                                            6.751        0.000                       0                     2  
-  pll_adc_clk          -5.778    -7003.639                   5940                34128       -0.048       -0.048                      1                34128        2.750        0.000                       0                 13377  
-  pll_dac_clk_1x        1.176        0.000                      0                   45       -0.198       -0.815                      7                   45        3.500        0.000                       0                    47  
+  pll_adc_clk          -4.865    -7220.550                   5971                34256       -0.070       -0.430                     12                34256        3.500        0.000                       0                 13372  
+  pll_dac_clk_1x        1.221        0.000                      0                   45       -0.210       -0.775                      8                   45        3.500        0.000                       0                    47  
   pll_dac_clk_2p                                                                                                                                                    1.845        0.000                       0                     3  
   pll_dac_clk_2x                                                                                                                                                    1.845        0.000                       0                     3  
-  pll_pwm_clk          -0.797       -5.729                     25                  412        0.034        0.000                      0                  412        1.500        0.000                       0                   217  
-clk_fpga_3             -2.406     -192.992                    267                 1839        0.016        0.000                      0                 1839        1.000        0.000                       0                   851  
+  pll_pwm_clk           0.000        0.000                      0                  440        0.158        0.000                      0                  440        1.500        0.000                       0                   217  
+clk_fpga_3              0.003        0.000                      0                 1663        0.122        0.000                      0                 1663        1.000        0.000                       0                   751  
 
 
 ------------------------------------------------------------------------------------------------
@@ -177,9 +189,9 @@ clk_fpga_3             -2.406     -192.992                    267               
 
 From Clock      To Clock            WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints  
 ----------      --------            -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------  
-adc_clk         pll_adc_clk           6.426        0.000                      0                   28       -2.537      -69.334                     28                   28  
-pll_adc_clk     pll_dac_clk_1x        3.607        0.000                      0                   28        0.153        0.000                      0                   28  
-pll_adc_clk     pll_pwm_clk           0.427        0.000                      0                   94       -0.249       -8.164                     62                   94  
+adc_clk         pll_adc_clk           6.064        0.000                      0                   28       -1.762      -47.627                     28                   28  
+pll_adc_clk     pll_dac_clk_1x        3.742        0.000                      0                   28        0.032        0.000                      0                   28  
+pll_adc_clk     pll_pwm_clk           0.826        0.000                      0                   94       -0.293      -11.669                     84                   94  
 
 
 ------------------------------------------------------------------------------------------------
@@ -218,7 +230,7 @@ Check Type        Corner  Lib Pin           Reference Pin  Required(ns)  Actual(
 Min Period        n/a     PLLE2_ADV/CLKIN1  n/a            1.249         8.000       6.751      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
 Max Period        n/a     PLLE2_ADV/CLKIN1  n/a            52.633        8.000       44.633     PLLE2_ADV_X0Y0  pll/pll/CLKIN1
 Low Pulse Width   Slow    PLLE2_ADV/CLKIN1  n/a            2.000         4.000       2.000      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
-High Pulse Width  Fast    PLLE2_ADV/CLKIN1  n/a            2.000         4.000       2.000      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
+High Pulse Width  Slow    PLLE2_ADV/CLKIN1  n/a            2.000         4.000       2.000      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
 
 
 
@@ -249,28 +261,28 @@ Max Period  n/a     PLLE2_ADV/CLKFBIN   n/a            52.633        8.000      
 From Clock:  pll_adc_clk
   To Clock:  pll_adc_clk
 
-Setup :         5940  Failing Endpoints,  Worst Slack       -5.778ns,  Total Violation    -7003.639ns
-Hold  :            1  Failing Endpoint ,  Worst Slack       -0.048ns,  Total Violation       -0.048ns
-PW    :            0  Failing Endpoints,  Worst Slack        2.750ns,  Total Violation        0.000ns
+Setup :         5971  Failing Endpoints,  Worst Slack       -4.865ns,  Total Violation    -7220.550ns
+Hold  :           12  Failing Endpoints,  Worst Slack       -0.070ns,  Total Violation       -0.430ns
+PW    :            0  Failing Endpoints,  Worst Slack        3.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -5.778ns  (required time - arrival time)
-  Source:                 i_dsp/genblk4[4].iir/x0b_reg[15]/C
+Slack (VIOLATED) :        -4.865ns  (required time - arrival time)
+  Source:                 i_dsp/genblk4[4].iir/x0b_reg[16]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            i_dsp/genblk4[4].iir/overflow_reg[3]/D
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_adc_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            8.000ns  (pll_adc_clk rise@8.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        13.637ns  (logic 9.504ns (69.693%)  route 4.133ns (30.307%))
-  Logic Levels:           18  (CARRY4=13 DSP48E1=2 LUT2=2 LUT4=1)
-  Clock Path Skew:        -0.104ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.588ns = ( 13.588 - 8.000 ) 
-    Source Clock Delay      (SCD):    5.917ns
-    Clock Pessimism Removal (CPR):    0.225ns
+  Data Path Delay:        12.660ns  (logic 9.429ns (74.479%)  route 3.231ns (25.521%))
+  Logic Levels:           19  (CARRY4=14 DSP48E1=2 LUT1=1 LUT2=1 LUT5=1)
+  Clock Path Skew:        -0.165ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.520ns = ( 13.520 - 8.000 ) 
+    Source Clock Delay      (SCD):    5.909ns
+    Clock Pessimism Removal (CPR):    0.224ns
   Clock Uncertainty:      0.069ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
     Discrete Jitter          (DJ):    0.118ns
@@ -288,63 +300,66 @@ Slack (VIOLATED) :        -5.778ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    1.684     5.917    i_dsp/genblk4[4].iir/clk_i
-    SLICE_X12Y6          FDRE                                         r  i_dsp/genblk4[4].iir/x0b_reg[15]/C
+                         net (fo=13385, estimated)    1.676     5.909    i_dsp/genblk4[4].iir/clk_i
+    SLICE_X33Y8          FDRE                                         r  i_dsp/genblk4[4].iir/x0b_reg[16]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X12Y6          FDRE (Prop_fdre_C_Q)         0.518     6.435 r  i_dsp/genblk4[4].iir/x0b_reg[15]/Q
-                         net (fo=1, estimated)        1.170     7.605    i_dsp/genblk4[4].iir/p_bx0_module/factor1_i[15]
-    DSP48_X1Y0           DSP48E1 (Prop_dsp48e1_A[15]_PCOUT[47])
-                                                      4.036    11.641 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__1/PCOUT[47]
-                         net (fo=1, estimated)        0.000    11.641    i_dsp/genblk4[4].iir/p_bx0_module/product0__1_n_106
-    DSP48_X1Y1           DSP48E1 (Prop_dsp48e1_PCIN[47]_P[4])
-                                                      1.518    13.159 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[4]
-                         net (fo=2, estimated)        0.969    14.128    i_dsp/genblk4[4].iir/p_bx0_module/product0__2_n_101
-    SLICE_X32Y7          LUT2 (Prop_lut2_I0_O)        0.124    14.252 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_20/O
-                         net (fo=1, routed)           0.000    14.252    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_20_n_0
-    SLICE_X32Y7          CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.533    14.785 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_12/CO[3]
-                         net (fo=1, estimated)        0.000    14.785    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_12_n_0
-    SLICE_X32Y8          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    14.902 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_7/CO[3]
-                         net (fo=1, estimated)        0.000    14.902    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_7_n_0
-    SLICE_X32Y9          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.019 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2/CO[3]
-                         net (fo=1, estimated)        0.000    15.019    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2_n_0
-    SLICE_X32Y10         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.136 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.136    i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_6_n_0
-    SLICE_X32Y11         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.253 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.253    i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_6_n_0
-    SLICE_X32Y12         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.370 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.370    i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_6_n_0
-    SLICE_X32Y13         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.487 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.487    i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_6_n_0
-    SLICE_X32Y14         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.604 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.604    i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_6_n_0
-    SLICE_X32Y15         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.721 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.721    i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_6_n_0
-    SLICE_X32Y16         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.838 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_6/CO[3]
-                         net (fo=1, estimated)        0.000    15.838    i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_6_n_0
-    SLICE_X32Y17         CARRY4 (Prop_carry4_CI_O[0])
-                                                      0.219    16.057 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[31]_INST_0_i_3/O[0]
-                         net (fo=1, estimated)        0.806    16.863    i_dsp/genblk4[4].iir/p_bx0_module/product_o[31]_INST_0_i_3_n_7
-    SLICE_X36Y17         CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.845    17.708 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1/CO[3]
-                         net (fo=1, estimated)        0.000    17.708    i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1_n_0
-    SLICE_X36Y18         CARRY4 (Prop_carry4_CI_O[0])
-                                                      0.235    17.943 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[31]_INST_0_i_1/O[0]
-                         net (fo=33, estimated)       0.882    18.825    i_dsp/genblk4[4].iir/p_bx0_module/product_o[31]_INST_0_i_1_n_7
-    SLICE_X36Y19         LUT4 (Prop_lut4_I3_O)        0.299    19.124 r  i_dsp/genblk4[4].iir/p_bx0_module/overflow_INST_0/O
-                         net (fo=1, estimated)        0.306    19.430    i_dsp/genblk4[4].iir/overflow_i[3]
-    SLICE_X36Y21         LUT2 (Prop_lut2_I0_O)        0.124    19.554 r  i_dsp/genblk4[4].iir/overflow[3]_i_1/O
-                         net (fo=1, routed)           0.000    19.554    i_dsp/genblk4[4].iir/overflow[3]_i_1_n_0
-    SLICE_X36Y21         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/D
+    SLICE_X33Y8          FDRE (Prop_fdre_C_Q)         0.456     6.365 r  i_dsp/genblk4[4].iir/x0b_reg[16]/Q
+                         net (fo=1, estimated)        0.521     6.886    i_dsp/genblk4[4].iir/p_bx0_module/factor1_i[16]
+    DSP48_X1Y2           DSP48E1 (Prop_dsp48e1_A[16]_PCOUT[47])
+                                                      4.036    10.922 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__1/PCOUT[47]
+                         net (fo=1, estimated)        0.000    10.922    i_dsp/genblk4[4].iir/p_bx0_module/product0__1_n_106
+    DSP48_X1Y3           DSP48E1 (Prop_dsp48e1_PCIN[47]_P[0])
+                                                      1.518    12.440 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[0]
+                         net (fo=2, estimated)        0.960    13.400    i_dsp/genblk4[4].iir/p_bx0_module/product0__2_n_105
+    SLICE_X31Y1          LUT2 (Prop_lut2_I0_O)        0.124    13.524 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_16/O
+                         net (fo=1, routed)           0.000    13.524    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_16_n_0
+    SLICE_X31Y1          CARRY4 (Prop_carry4_S[1]_CO[3])
+                                                      0.550    14.074 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_9/CO[3]
+                         net (fo=1, estimated)        0.000    14.074    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_9_n_0
+    SLICE_X31Y2          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    14.188 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_4/CO[3]
+                         net (fo=1, estimated)        0.000    14.188    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_4_n_0
+    SLICE_X31Y3          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    14.302 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_3/CO[3]
+                         net (fo=1, estimated)        0.000    14.302    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_3_n_0
+    SLICE_X31Y4          CARRY4 (Prop_carry4_CI_O[0])
+                                                      0.222    14.524 f  i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_2/O[0]
+                         net (fo=2, estimated)        0.604    15.128    i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_2_n_7
+    SLICE_X29Y4          LUT1 (Prop_lut1_I0_O)        0.299    15.427 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2/O
+                         net (fo=1, routed)           0.000    15.427    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2_n_0
+    SLICE_X29Y4          CARRY4 (Prop_carry4_S[1]_CO[3])
+                                                      0.550    15.977 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    15.977    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_1_n_0
+    SLICE_X29Y5          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.091 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.091    i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_1_n_0
+    SLICE_X29Y6          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.205 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.205    i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_1_n_0
+    SLICE_X29Y7          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.319 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.319    i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_1_n_0
+    SLICE_X29Y8          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.433 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.433    i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_1_n_0
+    SLICE_X29Y9          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.547 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.547    i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_1_n_0
+    SLICE_X29Y10         CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.661 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.661    i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_1_n_0
+    SLICE_X29Y11         CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.775 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.775    i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_1_n_0
+    SLICE_X29Y12         CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.889 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1/CO[3]
+                         net (fo=1, estimated)        0.000    16.889    i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1_n_0
+    SLICE_X29Y13         CARRY4 (Prop_carry4_CI_O[0])
+                                                      0.235    17.124 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[31]_INST_0_i_1/O[0]
+                         net (fo=33, estimated)       1.146    18.270    i_dsp/genblk4[4].iir/p_bx0_full[31]
+    SLICE_X18Y14         LUT5 (Prop_lut5_I0_O)        0.299    18.569 r  i_dsp/genblk4[4].iir/overflow[3]_i_1_LOPT_REMAP/O
+                         net (fo=1, routed)           0.000    18.569    i_dsp/genblk4[4].iir/overflow[3]_i_1_n_0
+    SLICE_X18Y14         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_adc_clk rise edge)
@@ -357,16 +372,16 @@ Slack (VIOLATED) :        -5.778ns  (required time - arrival time)
                                                       0.084    10.265 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        1.666    11.931    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.091    12.022 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    1.566    13.588    i_dsp/genblk4[4].iir/clk_i
-    SLICE_X36Y21         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/C
-                         clock pessimism              0.225    13.813    
-                         clock uncertainty           -0.069    13.744    
-    SLICE_X36Y21         FDRE (Setup_fdre_C_D)        0.032    13.776    i_dsp/genblk4[4].iir/overflow_reg[3]
+                         net (fo=13385, estimated)    1.498    13.520    i_dsp/genblk4[4].iir/clk_i
+    SLICE_X18Y14         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/C
+                         clock pessimism              0.224    13.744    
+                         clock uncertainty           -0.069    13.675    
+    SLICE_X18Y14         FDRE (Setup_fdre_C_D)        0.029    13.704    i_dsp/genblk4[4].iir/overflow_reg[3]
   -------------------------------------------------------------------
-                         required time                         13.776    
-                         arrival time                         -19.554    
+                         required time                         13.704    
+                         arrival time                         -18.569    
   -------------------------------------------------------------------
-                         slack                                 -5.778    
+                         slack                                 -4.865    
 
 
 
@@ -374,20 +389,20 @@ Slack (VIOLATED) :        -5.778ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.048ns  (arrival time - required time)
-  Source:                 i_scope/adc_b_dat_reg[7]/C
+Slack (VIOLATED) :        -0.070ns  (arrival time - required time)
+  Source:                 i_scope/adc_wp_reg[11]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            i_scope/adc_b_buf_reg_3/DIADI[1]
+  Destination:            i_scope/adc_b_buf_reg_4/ADDRARDADDR[12]
                             (rising edge-triggered cell RAMB36E1 clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_adc_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_adc_clk rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.413ns  (logic 0.141ns (34.150%)  route 0.272ns (65.850%))
+  Data Path Delay:        0.430ns  (logic 0.164ns (38.141%)  route 0.266ns (61.859%))
   Logic Levels:           0  
-  Clock Path Skew:        0.305ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.735ns
-    Source Clock Delay      (SCD):    2.319ns
-    Clock Pessimism Removal (CPR):    0.110ns
+  Clock Path Skew:        0.316ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.752ns
+    Source Clock Delay      (SCD):    2.330ns
+    Clock Pessimism Removal (CPR):    0.105ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -401,12 +416,12 @@ Slack (VIOLATED) :        -0.048ns  (arrival time - required time)
                                                       0.051     1.003 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        0.739     1.742    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     1.768 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    0.551     2.319    i_scope/adc_clk_i
-    SLICE_X21Y64         FDRE                                         r  i_scope/adc_b_dat_reg[7]/C
+                         net (fo=13385, estimated)    0.562     2.330    i_scope/adc_clk_i
+    SLICE_X6Y50          FDRE                                         r  i_scope/adc_wp_reg[11]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X21Y64         FDRE (Prop_fdre_C_Q)         0.141     2.460 r  i_scope/adc_b_dat_reg[7]/Q
-                         net (fo=9, estimated)        0.272     2.732    i_scope/adc_b_dat[7]
-    RAMB36_X1Y13         RAMB36E1                                     r  i_scope/adc_b_buf_reg_3/DIADI[1]
+    SLICE_X6Y50          FDRE (Prop_fdre_C_Q)         0.164     2.494 r  i_scope/adc_wp_reg[11]/Q
+                         net (fo=16, estimated)       0.266     2.760    i_scope/adc_wp_reg[11]
+    RAMB36_X0Y9          RAMB36E1                                     r  i_scope/adc_b_buf_reg_4/ADDRARDADDR[12]
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_adc_clk rise edge)
@@ -419,16 +434,16 @@ Slack (VIOLATED) :        -0.048ns  (arrival time - required time)
                                                       0.054     1.066 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        0.778     1.845    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.029     1.874 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    0.861     2.735    i_scope/adc_clk_i
-    RAMB36_X1Y13         RAMB36E1                                     r  i_scope/adc_b_buf_reg_3/CLKARDCLK
-                         clock pessimism             -0.110     2.625    
-    RAMB36_X1Y13         RAMB36E1 (Hold_ramb36e1_CLKARDCLK_DIADI[1])
-                                                      0.155     2.780    i_scope/adc_b_buf_reg_3
+                         net (fo=13385, estimated)    0.878     2.752    i_scope/adc_clk_i
+    RAMB36_X0Y9          RAMB36E1                                     r  i_scope/adc_b_buf_reg_4/CLKARDCLK
+                         clock pessimism             -0.105     2.647    
+    RAMB36_X0Y9          RAMB36E1 (Hold_ramb36e1_CLKARDCLK_ADDRARDADDR[12])
+                                                      0.183     2.830    i_scope/adc_b_buf_reg_4
   -------------------------------------------------------------------
-                         required time                         -2.780    
-                         arrival time                           2.732    
+                         required time                         -2.830    
+                         arrival time                           2.760    
   -------------------------------------------------------------------
-                         slack                                 -0.048    
+                         slack                                 -0.070    
 
 
 
@@ -442,10 +457,10 @@ Period(ns):         8.000
 Sources:            { pll/pll/CLKOUT0 }
 
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
-Min Period        n/a     DSP48E1/CLK        n/a            3.884         8.000       4.116      DSP48_X1Y32     i_dsp/genblk2[0].i_pid/kp_mult0/CLK
+Min Period        n/a     DSP48E1/CLK        n/a            3.884         8.000       4.116      DSP48_X0Y28     i_dsp/genblk2[0].i_pid/ki_mult_reg/CLK
 Max Period        n/a     PLLE2_ADV/CLKOUT0  n/a            160.000       8.000       152.000    PLLE2_ADV_X0Y0  pll/pll/CLKOUT0
-Low Pulse Width   Slow    RAMD32/CLK         n/a            1.250         4.000       2.750      SLICE_X4Y4      i_ps/axi_master[0]/axi_awfifo_reg_0_15_36_36/RAMA/CLK
-High Pulse Width  Slow    RAMD32/CLK         n/a            1.250         4.000       2.750      SLICE_X0Y4      i_ps/axi_master[0]/axi_awfifo_reg_0_15_30_35/RAMA/CLK
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X42Y44    adc_rstn_reg/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X42Y44    adc_rstn_reg/C
 
 
 
@@ -453,15 +468,15 @@ High Pulse Width  Slow    RAMD32/CLK         n/a            1.250         4.000 
 From Clock:  pll_dac_clk_1x
   To Clock:  pll_dac_clk_1x
 
-Setup :            0  Failing Endpoints,  Worst Slack        1.176ns,  Total Violation        0.000ns
-Hold  :            7  Failing Endpoints,  Worst Slack       -0.198ns,  Total Violation       -0.815ns
+Setup :            0  Failing Endpoints,  Worst Slack        1.221ns,  Total Violation        0.000ns
+Hold  :            8  Failing Endpoints,  Worst Slack       -0.210ns,  Total Violation       -0.775ns
 PW    :            0  Failing Endpoints,  Worst Slack        3.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             1.176ns  (required time - arrival time)
+Slack (MET) :             1.221ns  (required time - arrival time)
   Source:                 dac_rst_reg/C
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            oddr_dac_dat[13]/R
@@ -469,11 +484,11 @@ Slack (MET) :             1.176ns  (required time - arrival time)
   Path Group:             pll_dac_clk_1x
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_dac_clk_1x fall@4.000ns - pll_dac_clk_1x rise@0.000ns)
-  Data Path Delay:        2.282ns  (logic 0.456ns (19.982%)  route 1.826ns (80.018%))
+  Data Path Delay:        2.235ns  (logic 0.456ns (20.403%)  route 1.779ns (79.597%))
   Logic Levels:           0  
-  Clock Path Skew:        0.325ns (DCD - SCD + CPR)
+  Clock Path Skew:        0.323ns (DCD - SCD + CPR)
     Destination Clock Delay (DCD):    5.970ns = ( 9.970 - 4.000 ) 
-    Source Clock Delay      (SCD):    5.971ns
+    Source Clock Delay      (SCD):    5.973ns
     Clock Pessimism Removal (CPR):    0.326ns
   Clock Uncertainty:      0.069ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -492,11 +507,11 @@ Slack (MET) :             1.176ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT1
                          net (fo=1, estimated)        1.754     4.132    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_dac_clk_1x/O
-                         net (fo=45, estimated)       1.738     5.971    dac_clk_1x
-    SLICE_X43Y59         FDRE                                         r  dac_rst_reg/C
+                         net (fo=45, estimated)       1.740     5.973    dac_clk_1x
+    SLICE_X43Y55         FDRE                                         r  dac_rst_reg/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X43Y59         FDRE (Prop_fdre_C_Q)         0.456     6.427 r  dac_rst_reg/Q
-                         net (fo=17, estimated)       1.826     8.253    dac_rst
+    SLICE_X43Y55         FDRE (Prop_fdre_C_Q)         0.456     6.429 r  dac_rst_reg/Q
+                         net (fo=17, estimated)       1.779     8.208    dac_rst
     OLOGIC_X0Y92         ODDR                                         r  oddr_dac_dat[13]/R
   -------------------------------------------------------------------    -------------------
 
@@ -517,9 +532,9 @@ Slack (MET) :             1.176ns  (required time - arrival time)
     OLOGIC_X0Y92         ODDR (Setup_oddr_C_R)       -0.798     9.429    oddr_dac_dat[13]
   -------------------------------------------------------------------
                          required time                          9.429    
-                         arrival time                          -8.253    
+                         arrival time                          -8.208    
   -------------------------------------------------------------------
-                         slack                                  1.176    
+                         slack                                  1.221    
 
 
 
@@ -527,7 +542,7 @@ Slack (MET) :             1.176ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.198ns  (arrival time - required time)
+Slack (VIOLATED) :        -0.210ns  (arrival time - required time)
   Source:                 dac_rst_reg/C
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            oddr_dac_sel/R
@@ -535,12 +550,12 @@ Slack (VIOLATED) :        -0.198ns  (arrival time - required time)
   Path Group:             pll_dac_clk_1x
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_dac_clk_1x rise@0.000ns - pll_dac_clk_1x rise@0.000ns)
-  Data Path Delay:        0.457ns  (logic 0.141ns (30.844%)  route 0.316ns (69.156%))
+  Data Path Delay:        0.445ns  (logic 0.141ns (31.661%)  route 0.304ns (68.339%))
   Logic Levels:           0  
   Clock Path Skew:        0.179ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    2.874ns
-    Source Clock Delay      (SCD):    2.354ns
-    Clock Pessimism Removal (CPR):    0.340ns
+    Source Clock Delay      (SCD):    2.355ns
+    Clock Pessimism Removal (CPR):    0.339ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -554,11 +569,11 @@ Slack (VIOLATED) :        -0.198ns  (arrival time - required time)
                                                       0.051     1.003 r  pll/pll/CLKOUT1
                          net (fo=1, estimated)        0.739     1.742    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.026     1.768 r  bufg_dac_clk_1x/O
-                         net (fo=45, estimated)       0.586     2.354    dac_clk_1x
-    SLICE_X43Y59         FDRE                                         r  dac_rst_reg/C
+                         net (fo=45, estimated)       0.587     2.355    dac_clk_1x
+    SLICE_X43Y55         FDRE                                         r  dac_rst_reg/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X43Y59         FDRE (Prop_fdre_C_Q)         0.141     2.495 r  dac_rst_reg/Q
-                         net (fo=17, estimated)       0.316     2.811    dac_rst
+    SLICE_X43Y55         FDRE (Prop_fdre_C_Q)         0.141     2.496 r  dac_rst_reg/Q
+                         net (fo=17, estimated)       0.304     2.801    dac_rst
     OLOGIC_X0Y57         ODDR                                         r  oddr_dac_sel/R
   -------------------------------------------------------------------    -------------------
 
@@ -574,13 +589,13 @@ Slack (VIOLATED) :        -0.198ns  (arrival time - required time)
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.029     1.874 r  bufg_dac_clk_1x/O
                          net (fo=45, estimated)       1.000     2.874    dac_clk_1x
     OLOGIC_X0Y57         ODDR                                         r  oddr_dac_sel/C
-                         clock pessimism             -0.340     2.533    
-    OLOGIC_X0Y57         ODDR (Hold_oddr_C_R)         0.476     3.009    oddr_dac_sel
+                         clock pessimism             -0.339     2.534    
+    OLOGIC_X0Y57         ODDR (Hold_oddr_C_R)         0.476     3.010    oddr_dac_sel
   -------------------------------------------------------------------
-                         required time                         -3.009    
-                         arrival time                           2.811    
+                         required time                         -3.010    
+                         arrival time                           2.801    
   -------------------------------------------------------------------
-                         slack                                 -0.198    
+                         slack                                 -0.210    
 
 
 
@@ -596,8 +611,8 @@ Sources:            { pll/pll/CLKOUT1 }
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
 Min Period        n/a     BUFG/I             n/a            2.155         8.000       5.845      BUFGCTRL_X0Y3   bufg_dac_clk_1x/I
 Max Period        n/a     PLLE2_ADV/CLKOUT1  n/a            160.000       8.000       152.000    PLLE2_ADV_X0Y0  pll/pll/CLKOUT1
-Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X43Y83    dac_dat_a_reg[12]/C
-High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X41Y86    dac_dat_a_reg[0]/C
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X41Y82    dac_dat_a_reg[0]/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X41Y82    dac_dat_a_reg[0]/C
 
 
 
@@ -651,28 +666,28 @@ Max Period  n/a     PLLE2_ADV/CLKOUT2  n/a            160.000       4.000       
 From Clock:  pll_pwm_clk
   To Clock:  pll_pwm_clk
 
-Setup :           25  Failing Endpoints,  Worst Slack       -0.797ns,  Total Violation       -5.729ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.034ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        0.000ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.158ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        1.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.797ns  (required time - arrival time)
-  Source:                 pwm[2]/vcnt_reg[4]/C
+Slack (MET) :             0.000ns  (required time - arrival time)
+  Source:                 pwm[0]/vcnt_reg[4]/C
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
-  Destination:            pwm[2]/b_reg[0]/CE
+  Destination:            pwm[0]/bcnt_reg[0]/CE
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_pwm_clk rise@4.000ns - pll_pwm_clk rise@0.000ns)
-  Data Path Delay:        4.569ns  (logic 0.842ns (18.429%)  route 3.727ns (81.571%))
-  Logic Levels:           2  (LUT4=1 LUT6=1)
-  Clock Path Skew:        0.004ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.576ns = ( 9.576 - 4.000 ) 
-    Source Clock Delay      (SCD):    5.898ns
-    Clock Pessimism Removal (CPR):    0.326ns
+  Data Path Delay:        3.501ns  (logic 0.990ns (28.278%)  route 2.511ns (71.722%))
+  Logic Levels:           3  (LUT3=1 LUT5=1 LUT6=1)
+  Clock Path Skew:        -0.023ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.594ns = ( 9.594 - 4.000 ) 
+    Source Clock Delay      (SCD):    5.980ns
+    Clock Pessimism Removal (CPR):    0.363ns
   Clock Uncertainty:      0.063ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
     Discrete Jitter          (DJ):    0.104ns
@@ -690,16 +705,18 @@ Slack (VIOLATED) :        -0.797ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT5
                          net (fo=1, estimated)        1.754     4.132    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_pwm_clk/O
-                         net (fo=215, estimated)      1.665     5.898    pwm[2]/clk
-    SLICE_X17Y19         FDRE                                         r  pwm[2]/vcnt_reg[4]/C
+                         net (fo=215, estimated)      1.747     5.980    pwm[0]/clk
+    SLICE_X39Y33         FDRE                                         r  pwm[0]/vcnt_reg[4]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X17Y19         FDRE (Prop_fdre_C_Q)         0.419     6.317 r  pwm[2]/vcnt_reg[4]/Q
-                         net (fo=4, estimated)        1.506     7.823    pwm[2]/vcnt_reg__0[4]
-    SLICE_X26Y16         LUT6 (Prop_lut6_I0_O)        0.299     8.122 f  pwm[2]/b[15]_i_3/O
-                         net (fo=5, estimated)        0.848     8.970    pwm[2]/b[15]_i_3_n_0
-    SLICE_X18Y16         LUT4 (Prop_lut4_I3_O)        0.124     9.094 r  pwm[2]/b[15]_i_1/O
-                         net (fo=16, estimated)       1.373    10.467    pwm[2]/b
-    SLICE_X4Y5           FDRE                                         r  pwm[2]/b_reg[0]/CE
+    SLICE_X39Y33         FDRE (Prop_fdre_C_Q)         0.419     6.399 r  pwm[0]/vcnt_reg[4]/Q
+                         net (fo=4, estimated)        0.860     7.259    pwm[0]/vcnt_reg[4]
+    SLICE_X38Y34         LUT6 (Prop_lut6_I0_O)        0.297     7.556 f  pwm[0]/b[14]_i_3/O
+                         net (fo=8, estimated)        0.442     7.998    pwm[0]/b[14]_i_3_n_0
+    SLICE_X39Y33         LUT3 (Prop_lut3_I2_O)        0.124     8.122 r  pwm[0]/bcnt[3]_i_1/O
+                         net (fo=1, estimated)        0.849     8.971    pwm[0]/bcnt
+    SLICE_X39Y33         LUT5 (Prop_lut5_I4_O)        0.150     9.121 r  pwm[0]/bcnt_reg[0]_CE_cooolgate_en_gate_1684_LOPT_REMAP/O
+                         net (fo=4, estimated)        0.360     9.481    pwm[0]/bcnt_reg[0]_CE_cooolgate_en_sig_129
+    SLICE_X39Y34         FDRE                                         r  pwm[0]/bcnt_reg[0]/CE
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -712,16 +729,16 @@ Slack (VIOLATED) :        -0.797ns  (required time - arrival time)
                                                       0.084     6.265 r  pll/pll/CLKOUT5
                          net (fo=1, estimated)        1.666     7.931    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.091     8.022 r  bufg_pwm_clk/O
-                         net (fo=215, estimated)      1.554     9.576    pwm[2]/clk
-    SLICE_X4Y5           FDRE                                         r  pwm[2]/b_reg[0]/C
-                         clock pessimism              0.326     9.902    
-                         clock uncertainty           -0.063     9.839    
-    SLICE_X4Y5           FDRE (Setup_fdre_C_CE)      -0.169     9.670    pwm[2]/b_reg[0]
+                         net (fo=215, estimated)      1.572     9.594    pwm[0]/clk
+    SLICE_X39Y34         FDRE                                         r  pwm[0]/bcnt_reg[0]/C
+                         clock pessimism              0.363     9.957    
+                         clock uncertainty           -0.063     9.894    
+    SLICE_X39Y34         FDRE (Setup_fdre_C_CE)      -0.413     9.481    pwm[0]/bcnt_reg[0]
   -------------------------------------------------------------------
-                         required time                          9.670    
-                         arrival time                         -10.467    
+                         required time                          9.481    
+                         arrival time                          -9.481    
   -------------------------------------------------------------------
-                         slack                                 -0.797    
+                         slack                                  0.000    
 
 
 
@@ -729,20 +746,20 @@ Slack (VIOLATED) :        -0.797ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.034ns  (arrival time - required time)
-  Source:                 pwm[0]/vcnt_reg[3]/C
+Slack (MET) :             0.158ns  (arrival time - required time)
+  Source:                 pwm_rstn_reg/C
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
-  Destination:            pwm[0]/vcnt_r_reg[3]/D
+  Destination:            pwm[3]/pwm_o_reg/R
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_pwm_clk rise@0.000ns - pll_pwm_clk rise@0.000ns)
-  Data Path Delay:        0.356ns  (logic 0.141ns (39.563%)  route 0.215ns (60.437%))
-  Logic Levels:           0  
-  Clock Path Skew:        0.263ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.702ns
-    Source Clock Delay      (SCD):    2.333ns
-    Clock Pessimism Removal (CPR):    0.105ns
+  Data Path Delay:        0.754ns  (logic 0.189ns (25.058%)  route 0.565ns (74.942%))
+  Logic Levels:           1  (LUT1=1)
+  Clock Path Skew:        0.186ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.881ns
+    Source Clock Delay      (SCD):    2.355ns
+    Clock Pessimism Removal (CPR):    0.339ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -756,12 +773,14 @@ Slack (MET) :             0.034ns  (arrival time - required time)
                                                       0.051     1.003 r  pll/pll/CLKOUT5
                          net (fo=1, estimated)        0.739     1.742    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.026     1.768 r  bufg_pwm_clk/O
-                         net (fo=215, estimated)      0.565     2.333    pwm[0]/clk
-    SLICE_X27Y49         FDRE                                         r  pwm[0]/vcnt_reg[3]/C
+                         net (fo=215, estimated)      0.587     2.355    pwm_clk
+    SLICE_X43Y32         FDRE                                         r  pwm_rstn_reg/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X27Y49         FDRE (Prop_fdre_C_Q)         0.141     2.474 r  pwm[0]/vcnt_reg[3]/Q
-                         net (fo=5, estimated)        0.215     2.690    pwm[0]/vcnt_reg__0[3]
-    SLICE_X30Y51         FDRE                                         r  pwm[0]/vcnt_r_reg[3]/D
+    SLICE_X43Y32         FDRE (Prop_fdre_C_Q)         0.141     2.496 f  pwm_rstn_reg/Q
+                         net (fo=87, estimated)       0.217     2.713    pwm[3]/rstn
+    SLICE_X42Y33         LUT1 (Prop_lut1_I0_O)        0.048     2.761 r  pwm[3]/pwm_o_i_1/O
+                         net (fo=13, estimated)       0.348     3.110    pwm[3]/clear
+    OLOGIC_X0Y44         FDRE                                         r  pwm[3]/pwm_o_reg/R
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -774,15 +793,15 @@ Slack (MET) :             0.034ns  (arrival time - required time)
                                                       0.054     1.066 r  pll/pll/CLKOUT5
                          net (fo=1, estimated)        0.778     1.845    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.029     1.874 r  bufg_pwm_clk/O
-                         net (fo=215, estimated)      0.828     2.702    pwm[0]/clk
-    SLICE_X30Y51         FDRE                                         r  pwm[0]/vcnt_r_reg[3]/C
-                         clock pessimism             -0.105     2.596    
-    SLICE_X30Y51         FDRE (Hold_fdre_C_D)         0.059     2.655    pwm[0]/vcnt_r_reg[3]
+                         net (fo=215, estimated)      1.007     2.881    pwm[3]/clk
+    OLOGIC_X0Y44         FDRE                                         r  pwm[3]/pwm_o_reg/C
+                         clock pessimism             -0.339     2.541    
+    OLOGIC_X0Y44         FDRE (Hold_fdre_C_R)         0.410     2.951    pwm[3]/pwm_o_reg
   -------------------------------------------------------------------
-                         required time                         -2.655    
-                         arrival time                           2.690    
+                         required time                         -2.951    
+                         arrival time                           3.110    
   -------------------------------------------------------------------
-                         slack                                  0.034    
+                         slack                                  0.158    
 
 
 
@@ -798,8 +817,8 @@ Sources:            { pll/pll/CLKOUT5 }
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
 Min Period        n/a     BUFG/I             n/a            2.155         4.000       1.845      BUFGCTRL_X0Y2   bufg_pwm_clk/I
 Max Period        n/a     PLLE2_ADV/CLKOUT5  n/a            160.000       4.000       156.000    PLLE2_ADV_X0Y0  pll/pll/CLKOUT5
-Low Pulse Width   Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X13Y50    pwm[0]/b_reg[11]/C
-High Pulse Width  Fast    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X11Y49    pwm[0]/b_reg[10]/C
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X43Y32    pwm_rstn_reg/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X43Y32    pwm_rstn_reg/C
 
 
 
@@ -807,27 +826,27 @@ High Pulse Width  Fast    FDRE/C             n/a            0.500         2.000 
 From Clock:  clk_fpga_3
   To Clock:  clk_fpga_3
 
-Setup :          267  Failing Endpoints,  Worst Slack       -2.406ns,  Total Violation     -192.992ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.016ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        0.003ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.122ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        1.000ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -2.406ns  (required time - arrival time)
-  Source:                 i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_wrack_reg/C
-                            (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
-  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/D
-                            (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
+Slack (MET) :             0.003ns  (required time - arrival time)
+  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                            (rising edge-triggered cell FDSE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
+  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[4]/CE
+                            (rising edge-triggered cell FDSE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
   Path Group:             clk_fpga_3
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            5.000ns  (clk_fpga_3 rise@5.000ns - clk_fpga_3 rise@0.000ns)
-  Data Path Delay:        7.120ns  (logic 3.426ns (48.118%)  route 3.694ns (51.882%))
-  Logic Levels:           8  (CARRY4=4 LUT2=1 LUT3=1 LUT4=1 LUT5=1)
-  Clock Path Skew:        -0.008ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    2.767ns = ( 7.767 - 5.000 ) 
-    Source Clock Delay      (SCD):    2.960ns
+  Data Path Delay:        4.729ns  (logic 1.250ns (26.433%)  route 3.479ns (73.567%))
+  Logic Levels:           4  (LUT2=1 LUT3=1 LUT5=1 LUT6=1)
+  Clock Path Skew:        -0.016ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    2.770ns = ( 7.770 - 5.000 ) 
+    Source Clock Delay      (SCD):    2.971ns
     Clock Pessimism Removal (CPR):    0.185ns
   Clock Uncertainty:      0.083ns  ((TSJ^2 + TIJ^2)^1/2 + DJ) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -842,32 +861,20 @@ Slack (VIOLATED) :        -2.406ns  (required time - arrival time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, estimated)        1.207     1.207    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.101     1.308 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, estimated)      1.652     2.960    i_ps/system_i/system_i/xadc/inst/bus2ip_clk
-    SLICE_X16Y66         FDRE                                         r  i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_wrack_reg/C
+                         net (fo=751, estimated)      1.663     2.971    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/clk
+    SLICE_X6Y62          FDSE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X16Y66         FDRE (Prop_fdre_C_Q)         0.518     3.478 r  i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_wrack_reg/Q
-                         net (fo=4, estimated)        0.546     4.024    i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/IP2Bus_WrAck
-    SLICE_X16Y66         LUT2 (Prop_lut2_I0_O)        0.150     4.174 r  i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/s_axi_wready_INST_0/O
-                         net (fo=5, estimated)        1.136     5.310    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/m_awready
-    SLICE_X10Y65         LUT5 (Prop_lut5_I2_O)        0.377     5.687 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/next_INST_0/O
-                         net (fo=26, estimated)       0.895     6.582    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/next
-    SLICE_X3Y65          LUT4 (Prop_lut4_I3_O)        0.331     6.913 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[0]_i_17/O
-                         net (fo=1, routed)           0.000     6.913    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[0]_i_17_n_0
-    SLICE_X3Y65          CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.550     7.463 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]_i_11/CO[3]
-                         net (fo=1, estimated)        0.000     7.463    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]_i_11_n_0
-    SLICE_X3Y66          CARRY4 (Prop_carry4_CI_O[1])
-                                                      0.334     7.797 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_6/O[1]
-                         net (fo=1, estimated)        0.646     8.443    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/C[5]
-    SLICE_X2Y66          LUT3 (Prop_lut3_I0_O)        0.303     8.746 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[4]_i_4/O
-                         net (fo=1, routed)           0.000     8.746    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[4]_i_4_n_0
-    SLICE_X2Y66          CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.550     9.296 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_1/CO[3]
-                         net (fo=1, estimated)        0.000     9.296    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_1_n_0
-    SLICE_X2Y67          CARRY4 (Prop_carry4_CI_O[3])
-                                                      0.313     9.609 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]_i_1/O[3]
-                         net (fo=1, estimated)        0.471    10.080    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]_i_1_n_4
-    SLICE_X4Y67          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/D
+    SLICE_X6Y62          FDSE (Prop_fdse_C_Q)         0.518     3.489 f  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/Q
+                         net (fo=18, estimated)       1.165     4.654    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]
+    SLICE_X5Y66          LUT5 (Prop_lut5_I2_O)        0.152     4.806 f  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/empty_INST_0/O
+                         net (fo=2, estimated)        0.824     5.630    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/tr_empty
+    SLICE_X9Y66          LUT3 (Prop_lut3_I0_O)        0.332     5.962 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0_i_1/O
+                         net (fo=10, estimated)       0.605     6.567    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/rd_en
+    SLICE_X7Y64          LUT2 (Prop_lut2_I1_O)        0.124     6.691 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read[4]_i_1/O
+                         net (fo=1, estimated)        0.292     6.983    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read[4]_i_1_n_0
+    SLICE_X7Y64          LUT6 (Prop_lut6_I5_O)        0.124     7.107 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_CE_cooolgate_en_gate_1678_LOPT_REMAP/O
+                         net (fo=5, estimated)        0.593     7.700    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_CE_cooolgate_en_sig_127
+    SLICE_X4Y63          FDSE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[4]/CE
   -------------------------------------------------------------------    -------------------
 
                          (clock clk_fpga_3 rise edge)
@@ -875,16 +882,16 @@ Slack (VIOLATED) :        -2.406ns  (required time - arrival time)
     PS7_X0Y0             PS7                          0.000     5.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, estimated)        1.147     6.147    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.091     6.238 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, estimated)      1.529     7.767    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/clk
-    SLICE_X4Y67          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/C
-                         clock pessimism              0.185     7.952    
-                         clock uncertainty           -0.083     7.869    
-    SLICE_X4Y67          FDRE (Setup_fdre_C_D)       -0.195     7.674    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]
+                         net (fo=751, estimated)      1.532     7.770    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/clk
+    SLICE_X4Y63          FDSE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[4]/C
+                         clock pessimism              0.185     7.955    
+                         clock uncertainty           -0.083     7.872    
+    SLICE_X4Y63          FDSE (Setup_fdse_C_CE)      -0.169     7.703    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[4]
   -------------------------------------------------------------------
-                         required time                          7.674    
-                         arrival time                         -10.080    
+                         required time                          7.703    
+                         arrival time                          -7.700    
   -------------------------------------------------------------------
-                         slack                                 -2.406    
+                         slack                                  0.003    
 
 
 
@@ -892,20 +899,20 @@ Slack (VIOLATED) :        -2.406ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.016ns  (arrival time - required time)
-  Source:                 i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[14]/C
+Slack (MET) :             0.122ns  (arrival time - required time)
+  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/r_arid_r_reg[0]/C
                             (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
-  Destination:            i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/s_axi_rdata_i_reg[17]/D
-                            (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
+  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][1]_srl32/D
+                            (rising edge-triggered cell SRLC32E clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
   Path Group:             clk_fpga_3
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (clk_fpga_3 rise@0.000ns - clk_fpga_3 rise@0.000ns)
-  Data Path Delay:        0.348ns  (logic 0.141ns (40.521%)  route 0.207ns (59.479%))
+  Data Path Delay:        0.339ns  (logic 0.141ns (41.631%)  route 0.198ns (58.369%))
   Logic Levels:           0  
-  Clock Path Skew:        0.266ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    1.383ns
-    Source Clock Delay      (SCD):    1.082ns
-    Clock Pessimism Removal (CPR):    0.035ns
+  Clock Path Skew:        0.034ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    1.412ns
+    Source Clock Delay      (SCD):    1.114ns
+    Clock Pessimism Removal (CPR):    0.264ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -914,12 +921,12 @@ Slack (MET) :             0.016ns  (arrival time - required time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, estimated)        0.509     0.509    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.026     0.535 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, estimated)      0.547     1.082    i_ps/system_i/system_i/xadc/inst/bus2ip_clk
-    SLICE_X22Y69         FDRE                                         r  i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[14]/C
+                         net (fo=751, estimated)      0.579     1.114    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/clk
+    SLICE_X5Y59          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/r_arid_r_reg[0]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X22Y69         FDRE (Prop_fdre_C_Q)         0.141     1.223 r  i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[14]/Q
-                         net (fo=1, estimated)        0.207     1.430    i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/IP2Bus_Data[17]
-    SLICE_X21Y68         FDRE                                         r  i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/s_axi_rdata_i_reg[17]/D
+    SLICE_X5Y59          FDRE (Prop_fdre_C_Q)         0.141     1.255 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/r_arid_r_reg[0]/Q
+                         net (fo=1, estimated)        0.198     1.452    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/din[1]
+    SLICE_X0Y58          SRLC32E                                      r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][1]_srl32/D
   -------------------------------------------------------------------    -------------------
 
                          (clock clk_fpga_3 rise edge)
@@ -927,15 +934,16 @@ Slack (MET) :             0.016ns  (arrival time - required time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, estimated)        0.536     0.536    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.029     0.565 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, estimated)      0.818     1.383    i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/s_axi_aclk
-    SLICE_X21Y68         FDRE                                         r  i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/s_axi_rdata_i_reg[17]/C
-                         clock pessimism             -0.035     1.348    
-    SLICE_X21Y68         FDRE (Hold_fdre_C_D)         0.066     1.414    i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/s_axi_rdata_i_reg[17]
+                         net (fo=751, estimated)      0.847     1.412    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/clk
+    SLICE_X0Y58          SRLC32E                                      r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][1]_srl32/CLK
+                         clock pessimism             -0.264     1.148    
+    SLICE_X0Y58          SRLC32E (Hold_srlc32e_CLK_D)
+                                                      0.183     1.331    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][1]_srl32
   -------------------------------------------------------------------
-                         required time                         -1.414    
-                         arrival time                           1.430    
+                         required time                         -1.331    
+                         arrival time                           1.452    
   -------------------------------------------------------------------
-                         slack                                  0.016    
+                         slack                                  0.122    
 
 
 
@@ -950,8 +958,8 @@ Sources:            { i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKC
 
 Check Type        Corner  Lib Pin      Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location     Pin
 Min Period        n/a     XADC/DCLK    n/a            4.000         5.000       1.000      XADC_X0Y0    i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DCLK
-Low Pulse Width   Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X6Y58  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][13]_srl32/CLK
-High Pulse Width  Fast    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X0Y58  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][10]_srl32/CLK
+Low Pulse Width   Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X6Y65  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
+High Pulse Width  Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X6Y65  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
 
 
 
@@ -959,14 +967,14 @@ High Pulse Width  Fast    SRLC32E/CLK  n/a            0.980         2.500       
 From Clock:  adc_clk
   To Clock:  pll_adc_clk
 
-Setup :            0  Failing Endpoints,  Worst Slack        6.426ns,  Total Violation        0.000ns
-Hold  :           28  Failing Endpoints,  Worst Slack       -2.537ns,  Total Violation      -69.334ns
+Setup :            0  Failing Endpoints,  Worst Slack        6.064ns,  Total Violation        0.000ns
+Hold  :           28  Failing Endpoints,  Worst Slack       -1.762ns,  Total Violation      -47.627ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             6.426ns  (required time - arrival time)
+Slack (MET) :             6.064ns  (required time - arrival time)
   Source:                 adc_dat_a_i[7]
                             (input port clocked by adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            adc_dat_a_reg[5]/D
@@ -974,7 +982,7 @@ Slack (MET) :             6.426ns  (required time - arrival time)
   Path Group:             pll_adc_clk
   Path Type:              Setup (Max at Fast Process Corner)
   Requirement:            8.000ns  (pll_adc_clk rise@8.000ns - adc_clk rise@0.000ns)
-  Data Path Delay:        0.488ns  (logic 0.488ns (100.000%)  route 0.000ns (0.000%))
+  Data Path Delay:        0.850ns  (logic 0.488ns (57.440%)  route 0.362ns (42.560%))
   Logic Levels:           1  (IBUF=1)
   Input Delay:            3.400ns
   Clock Path Skew:        2.481ns (DCD - SCD + CPR)
@@ -993,7 +1001,7 @@ Slack (MET) :             6.426ns  (required time - arrival time)
     Y14                                               0.000     3.400 r  adc_dat_a_i[7] (IN)
                          net (fo=0)                   0.000     3.400    adc_dat_a_i[7]
     Y14                  IBUF (Prop_ibuf_I_O)         0.488     3.888 r  adc_dat_a_i_IBUF[7]_inst/O
-                         net (fo=1, estimated)        0.000     3.888    adc_dat_a_i_IBUF[7]
+                         net (fo=1, estimated)        0.362     4.250    adc_dat_a_i_IBUF[7]
     ILOGIC_X0Y33         FDRE                                         r  adc_dat_a_reg[5]/D
   -------------------------------------------------------------------    -------------------
 
@@ -1007,16 +1015,16 @@ Slack (MET) :             6.426ns  (required time - arrival time)
                                                       0.051     9.003 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        0.739     9.742    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     9.768 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    0.713    10.481    adc_clk
+                         net (fo=13385, estimated)    0.713    10.481    adc_clk
     ILOGIC_X0Y33         FDRE                                         r  adc_dat_a_reg[5]/C
                          clock pessimism              0.000    10.481    
                          clock uncertainty           -0.166    10.315    
-    ILOGIC_X0Y33         FDRE (Setup_fdre_C_D)       -0.001    10.314    adc_dat_a_reg[5]
+    ILOGIC_X0Y33         FDRE (Setup_fdre_C_D)       -0.002    10.313    adc_dat_a_reg[5]
   -------------------------------------------------------------------
-                         required time                         10.314    
-                         arrival time                          -3.888    
+                         required time                         10.313    
+                         arrival time                          -4.250    
   -------------------------------------------------------------------
-                         slack                                  6.426    
+                         slack                                  6.064    
 
 
 
@@ -1024,7 +1032,7 @@ Slack (MET) :             6.426ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -2.537ns  (arrival time - required time)
+Slack (VIOLATED) :        -1.762ns  (arrival time - required time)
   Source:                 adc_dat_b_i[3]
                             (input port clocked by adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            adc_dat_b_reg[1]/D
@@ -1032,7 +1040,7 @@ Slack (VIOLATED) :        -2.537ns  (arrival time - required time)
   Path Group:             pll_adc_clk
   Path Type:              Hold (Min at Slow Process Corner)
   Requirement:            0.000ns  (pll_adc_clk rise@0.000ns - adc_clk rise@0.000ns)
-  Data Path Delay:        0.805ns  (logic 0.805ns (100.000%)  route 0.000ns (0.000%))
+  Data Path Delay:        1.579ns  (logic 0.805ns (50.978%)  route 0.774ns (49.022%))
   Logic Levels:           1  (IBUF=1)
   Input Delay:            3.400ns
   Clock Path Skew:        6.384ns (DCD - SCD - CPR)
@@ -1051,7 +1059,7 @@ Slack (VIOLATED) :        -2.537ns  (arrival time - required time)
     P16                                               0.000     3.400 r  adc_dat_b_i[3] (IN)
                          net (fo=0)                   0.000     3.400    adc_dat_b_i[3]
     P16                  IBUF (Prop_ibuf_I_O)         0.805     4.205 r  adc_dat_b_i_IBUF[3]_inst/O
-                         net (fo=1, estimated)        0.000     4.205    adc_dat_b_i_IBUF[3]
+                         net (fo=1, estimated)        0.774     4.979    adc_dat_b_i_IBUF[3]
     ILOGIC_X0Y1          FDRE                                         r  adc_dat_b_reg[1]/D
   -------------------------------------------------------------------    -------------------
 
@@ -1065,16 +1073,16 @@ Slack (VIOLATED) :        -2.537ns  (arrival time - required time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    2.151     6.384    adc_clk
+                         net (fo=13385, estimated)    2.151     6.384    adc_clk
     ILOGIC_X0Y1          FDRE                                         r  adc_dat_b_reg[1]/C
                          clock pessimism              0.000     6.384    
                          clock uncertainty            0.166     6.550    
-    ILOGIC_X0Y1          FDRE (Hold_fdre_C_D)         0.192     6.742    adc_dat_b_reg[1]
+    ILOGIC_X0Y1          FDRE (Hold_fdre_C_D)         0.191     6.741    adc_dat_b_reg[1]
   -------------------------------------------------------------------
-                         required time                         -6.742    
-                         arrival time                           4.205    
+                         required time                         -6.741    
+                         arrival time                           4.979    
   -------------------------------------------------------------------
-                         slack                                 -2.537    
+                         slack                                 -1.762    
 
 
 
@@ -1084,26 +1092,26 @@ Slack (VIOLATED) :        -2.537ns  (arrival time - required time)
 From Clock:  pll_adc_clk
   To Clock:  pll_dac_clk_1x
 
-Setup :            0  Failing Endpoints,  Worst Slack        3.607ns,  Total Violation        0.000ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.153ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        3.742ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.032ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             3.607ns  (required time - arrival time)
-  Source:                 i_dsp/sum1_reg[14]/C
+Slack (MET) :             3.742ns  (required time - arrival time)
+  Source:                 i_dsp/sum2_reg[14]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            dac_dat_a_reg[5]/D
+  Destination:            dac_dat_b_reg[12]/D
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_dac_clk_1x
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            8.000ns  (pll_dac_clk_1x rise@8.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        3.912ns  (logic 0.642ns (16.411%)  route 3.270ns (83.589%))
+  Data Path Delay:        3.710ns  (logic 0.580ns (15.633%)  route 3.130ns (84.367%))
   Logic Levels:           1  (LUT6=1)
-  Clock Path Skew:        -0.225ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.573ns = ( 13.573 - 8.000 ) 
-    Source Clock Delay      (SCD):    5.911ns
+  Clock Path Skew:        -0.292ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.580ns = ( 13.580 - 8.000 ) 
+    Source Clock Delay      (SCD):    5.985ns
     Clock Pessimism Removal (CPR):    0.113ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1122,14 +1130,14 @@ Slack (MET) :             3.607ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    1.678     5.911    i_dsp/clk_i
-    SLICE_X30Y47         FDRE                                         r  i_dsp/sum1_reg[14]/C
+                         net (fo=13385, estimated)    1.752     5.985    i_dsp/clk_i
+    SLICE_X39Y38         FDRE                                         r  i_dsp/sum2_reg[14]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X30Y47         FDRE (Prop_fdre_C_Q)         0.518     6.429 f  i_dsp/sum1_reg[14]/Q
-                         net (fo=14, estimated)       1.437     7.866    i_dsp/dac_saturate[0]/input_i[14]
-    SLICE_X21Y53         LUT6 (Prop_lut6_I1_O)        0.124     7.990 r  i_dsp/dac_saturate[0]/output_o[5]_INST_0/O
-                         net (fo=15, estimated)       1.833     9.823    dac_dat_a[5]_i_1_n_0
-    SLICE_X43Y79         FDRE                                         r  dac_dat_a_reg[5]/D
+    SLICE_X39Y38         FDRE (Prop_fdre_C_Q)         0.456     6.441 f  i_dsp/sum2_reg[14]/Q
+                         net (fo=14, estimated)       1.145     7.586    i_dsp/dac_saturate[1]/input_i[14]
+    SLICE_X43Y35         LUT6 (Prop_lut6_I1_O)        0.124     7.710 r  i_dsp/dac_saturate[1]/output_o[12]_INST_0/O
+                         net (fo=15, estimated)       1.985     9.695    dac_dat_b[12]_i_1_n_0
+    SLICE_X43Y87         FDRE                                         r  dac_dat_b_reg[12]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_dac_clk_1x rise edge)
@@ -1142,16 +1150,16 @@ Slack (MET) :             3.607ns  (required time - arrival time)
                                                       0.084    10.265 r  pll/pll/CLKOUT1
                          net (fo=1, estimated)        1.666    11.931    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.091    12.022 r  bufg_dac_clk_1x/O
-                         net (fo=45, estimated)       1.551    13.573    dac_clk_1x
-    SLICE_X43Y79         FDRE                                         r  dac_dat_a_reg[5]/C
-                         clock pessimism              0.113    13.686    
-                         clock uncertainty           -0.189    13.498    
-    SLICE_X43Y79         FDRE (Setup_fdre_C_D)       -0.067    13.431    dac_dat_a_reg[5]
+                         net (fo=45, estimated)       1.558    13.580    dac_clk_1x
+    SLICE_X43Y87         FDRE                                         r  dac_dat_b_reg[12]/C
+                         clock pessimism              0.113    13.693    
+                         clock uncertainty           -0.189    13.505    
+    SLICE_X43Y87         FDRE (Setup_fdre_C_D)       -0.067    13.438    dac_dat_b_reg[12]
   -------------------------------------------------------------------
-                         required time                         13.431    
-                         arrival time                          -9.823    
+                         required time                         13.438    
+                         arrival time                          -9.695    
   -------------------------------------------------------------------
-                         slack                                  3.607    
+                         slack                                  3.742    
 
 
 
@@ -1159,19 +1167,19 @@ Slack (MET) :             3.607ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.153ns  (arrival time - required time)
-  Source:                 i_dsp/sum2_reg[16]/C
+Slack (MET) :             0.032ns  (arrival time - required time)
+  Source:                 i_dsp/sum2_reg[17]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            dac_dat_b_reg[7]/D
+  Destination:            dac_dat_b_reg[13]/D
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_dac_clk_1x
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_dac_clk_1x rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.718ns  (logic 0.186ns (25.922%)  route 0.532ns (74.078%))
-  Logic Levels:           1  (LUT6=1)
+  Data Path Delay:        0.599ns  (logic 0.141ns (23.532%)  route 0.458ns (76.468%))
+  Logic Levels:           0  
   Clock Path Skew:        0.306ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.724ns
-    Source Clock Delay      (SCD):    2.354ns
+    Destination Clock Delay (DCD):    2.727ns
+    Source Clock Delay      (SCD):    2.357ns
     Clock Pessimism Removal (CPR):    0.063ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1190,14 +1198,12 @@ Slack (MET) :             0.153ns  (arrival time - required time)
                                                       0.051     1.003 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        0.739     1.742    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     1.768 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    0.586     2.354    i_dsp/clk_i
-    SLICE_X36Y52         FDRE                                         r  i_dsp/sum2_reg[16]/C
+                         net (fo=13385, estimated)    0.589     2.357    i_dsp/clk_i
+    SLICE_X39Y39         FDRE                                         r  i_dsp/sum2_reg[17]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X36Y52         FDRE (Prop_fdre_C_Q)         0.141     2.495 f  i_dsp/sum2_reg[16]/Q
-                         net (fo=14, estimated)       0.286     2.782    i_dsp/dac_saturate[1]/input_i[16]
-    SLICE_X36Y58         LUT6 (Prop_lut6_I4_O)        0.045     2.827 r  i_dsp/dac_saturate[1]/output_o[7]_INST_0/O
-                         net (fo=15, estimated)       0.245     3.072    dac_dat_b[7]_i_1_n_0
-    SLICE_X39Y65         FDRE                                         r  dac_dat_b_reg[7]/D
+    SLICE_X39Y39         FDRE (Prop_fdre_C_Q)         0.141     2.498 r  i_dsp/sum2_reg[17]/Q
+                         net (fo=29, estimated)       0.458     2.957    dac_b[13]
+    SLICE_X41Y64         FDRE                                         r  dac_dat_b_reg[13]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_dac_clk_1x rise edge)
@@ -1210,16 +1216,16 @@ Slack (MET) :             0.153ns  (arrival time - required time)
                                                       0.054     1.066 r  pll/pll/CLKOUT1
                          net (fo=1, estimated)        0.778     1.845    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.029     1.874 r  bufg_dac_clk_1x/O
-                         net (fo=45, estimated)       0.850     2.724    dac_clk_1x
-    SLICE_X39Y65         FDRE                                         r  dac_dat_b_reg[7]/C
-                         clock pessimism             -0.063     2.660    
-                         clock uncertainty            0.189     2.849    
-    SLICE_X39Y65         FDRE (Hold_fdre_C_D)         0.070     2.919    dac_dat_b_reg[7]
+                         net (fo=45, estimated)       0.853     2.727    dac_clk_1x
+    SLICE_X41Y64         FDRE                                         r  dac_dat_b_reg[13]/C
+                         clock pessimism             -0.063     2.663    
+                         clock uncertainty            0.189     2.852    
+    SLICE_X41Y64         FDRE (Hold_fdre_C_D)         0.072     2.924    dac_dat_b_reg[13]
   -------------------------------------------------------------------
-                         required time                         -2.919    
-                         arrival time                           3.072    
+                         required time                         -2.924    
+                         arrival time                           2.957    
   -------------------------------------------------------------------
-                         slack                                  0.153    
+                         slack                                  0.032    
 
 
 
@@ -1229,26 +1235,26 @@ Slack (MET) :             0.153ns  (arrival time - required time)
 From Clock:  pll_adc_clk
   To Clock:  pll_pwm_clk
 
-Setup :            0  Failing Endpoints,  Worst Slack        0.427ns,  Total Violation        0.000ns
-Hold  :           62  Failing Endpoints,  Worst Slack       -0.249ns,  Total Violation       -8.164ns
+Setup :            0  Failing Endpoints,  Worst Slack        0.826ns,  Total Violation        0.000ns
+Hold  :           84  Failing Endpoints,  Worst Slack       -0.293ns,  Total Violation      -11.669ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.427ns  (required time - arrival time)
-  Source:                 i_ams/dac_c_o_reg[15]/C
+Slack (MET) :             0.826ns  (required time - arrival time)
+  Source:                 i_ams/dac_a_o_reg[14]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            pwm[2]/b_reg[15]/D
+  Destination:            pwm[0]/b_reg[14]/D
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_pwm_clk rise@4.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        3.061ns  (logic 0.580ns (18.948%)  route 2.481ns (81.052%))
+  Data Path Delay:        2.722ns  (logic 0.580ns (21.308%)  route 2.142ns (78.692%))
   Logic Levels:           1  (LUT5=1)
-  Clock Path Skew:        -0.276ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.514ns = ( 9.514 - 4.000 ) 
-    Source Clock Delay      (SCD):    5.903ns
+  Clock Path Skew:        -0.196ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.591ns = ( 9.591 - 4.000 ) 
+    Source Clock Delay      (SCD):    5.900ns
     Clock Pessimism Removal (CPR):    0.113ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1267,14 +1273,14 @@ Slack (MET) :             0.427ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    1.670     5.903    i_ams/clk_i
-    SLICE_X23Y39         FDRE                                         r  i_ams/dac_c_o_reg[15]/C
+                         net (fo=13385, estimated)    1.667     5.900    i_ams/clk_i
+    SLICE_X23Y35         FDRE                                         r  i_ams/dac_a_o_reg[14]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X23Y39         FDRE (Prop_fdre_C_Q)         0.456     6.359 r  i_ams/dac_c_o_reg[15]/Q
-                         net (fo=2, estimated)        1.841     8.200    pwm[2]/cfg[15]
-    SLICE_X22Y17         LUT5 (Prop_lut5_I0_O)        0.124     8.324 r  pwm[2]/b[15]_i_2/O
-                         net (fo=1, estimated)        0.640     8.964    pwm[2]/b[15]_i_2_n_0
-    SLICE_X19Y20         FDRE                                         r  pwm[2]/b_reg[15]/D
+    SLICE_X23Y35         FDRE (Prop_fdre_C_Q)         0.456     6.356 r  i_ams/dac_a_o_reg[14]/Q
+                         net (fo=2, estimated)        1.669     8.025    pwm[0]/cfg[14]
+    SLICE_X40Y32         LUT5 (Prop_lut5_I0_O)        0.124     8.149 r  pwm[0]/b[14]_i_2/O
+                         net (fo=1, estimated)        0.473     8.622    pwm[0]/p_0_in[14]
+    SLICE_X41Y31         FDRE                                         r  pwm[0]/b_reg[14]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -1287,16 +1293,16 @@ Slack (MET) :             0.427ns  (required time - arrival time)
                                                       0.084     6.265 r  pll/pll/CLKOUT5
                          net (fo=1, estimated)        1.666     7.931    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.091     8.022 r  bufg_pwm_clk/O
-                         net (fo=215, estimated)      1.492     9.514    pwm[2]/clk
-    SLICE_X19Y20         FDRE                                         r  pwm[2]/b_reg[15]/C
-                         clock pessimism              0.113     9.627    
-                         clock uncertainty           -0.189     9.439    
-    SLICE_X19Y20         FDRE (Setup_fdre_C_D)       -0.047     9.392    pwm[2]/b_reg[15]
+                         net (fo=215, estimated)      1.569     9.591    pwm[0]/clk
+    SLICE_X41Y31         FDRE                                         r  pwm[0]/b_reg[14]/C
+                         clock pessimism              0.113     9.704    
+                         clock uncertainty           -0.189     9.516    
+    SLICE_X41Y31         FDRE (Setup_fdre_C_D)       -0.067     9.449    pwm[0]/b_reg[14]
   -------------------------------------------------------------------
-                         required time                          9.392    
-                         arrival time                          -8.964    
+                         required time                          9.449    
+                         arrival time                          -8.622    
   -------------------------------------------------------------------
-                         slack                                  0.427    
+                         slack                                  0.826    
 
 
 
@@ -1304,19 +1310,19 @@ Slack (MET) :             0.427ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.249ns  (arrival time - required time)
-  Source:                 i_ams/dac_d_o_reg[22]/C
+Slack (VIOLATED) :        -0.293ns  (arrival time - required time)
+  Source:                 i_ams/dac_c_o_reg[23]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            pwm[3]/v_reg[6]/D
+  Destination:            pwm[2]/v_reg[7]/D
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_pwm_clk rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.318ns  (logic 0.164ns (51.528%)  route 0.154ns (48.472%))
+  Data Path Delay:        0.215ns  (logic 0.128ns (59.464%)  route 0.087ns (40.536%))
   Logic Levels:           0  
-  Clock Path Skew:        0.308ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.702ns
-    Source Clock Delay      (SCD):    2.330ns
+  Clock Path Skew:        0.309ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.725ns
+    Source Clock Delay      (SCD):    2.352ns
     Clock Pessimism Removal (CPR):    0.063ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1335,12 +1341,12 @@ Slack (VIOLATED) :        -0.249ns  (arrival time - required time)
                                                       0.051     1.003 r  pll/pll/CLKOUT0
                          net (fo=1, estimated)        0.739     1.742    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     1.768 r  bufg_adc_clk/O
-                         net (fo=13384, estimated)    0.562     2.330    i_ams/clk_i
-    SLICE_X20Y49         FDRE                                         r  i_ams/dac_d_o_reg[22]/C
+                         net (fo=13385, estimated)    0.584     2.352    i_ams/clk_i
+    SLICE_X39Y31         FDRE                                         r  i_ams/dac_c_o_reg[23]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X20Y49         FDRE (Prop_fdre_C_Q)         0.164     2.494 r  i_ams/dac_d_o_reg[22]/Q
-                         net (fo=2, estimated)        0.154     2.649    pwm[3]/cfg[22]
-    SLICE_X18Y50         FDRE                                         r  pwm[3]/v_reg[6]/D
+    SLICE_X39Y31         FDRE (Prop_fdre_C_Q)         0.128     2.480 r  i_ams/dac_c_o_reg[23]/Q
+                         net (fo=2, estimated)        0.087     2.568    pwm[2]/cfg[23]
+    SLICE_X38Y31         FDRE                                         r  pwm[2]/v_reg[7]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -1353,16 +1359,16 @@ Slack (VIOLATED) :        -0.249ns  (arrival time - required time)
                                                       0.054     1.066 r  pll/pll/CLKOUT5
                          net (fo=1, estimated)        0.778     1.845    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.029     1.874 r  bufg_pwm_clk/O
-                         net (fo=215, estimated)      0.828     2.702    pwm[3]/clk
-    SLICE_X18Y50         FDRE                                         r  pwm[3]/v_reg[6]/C
-                         clock pessimism             -0.063     2.638    
-                         clock uncertainty            0.189     2.827    
-    SLICE_X18Y50         FDRE (Hold_fdre_C_D)         0.070     2.897    pwm[3]/v_reg[6]
+                         net (fo=215, estimated)      0.851     2.725    pwm[2]/clk
+    SLICE_X38Y31         FDRE                                         r  pwm[2]/v_reg[7]/C
+                         clock pessimism             -0.063     2.661    
+                         clock uncertainty            0.189     2.850    
+    SLICE_X38Y31         FDRE (Hold_fdre_C_D)         0.010     2.860    pwm[2]/v_reg[7]
   -------------------------------------------------------------------
-                         required time                         -2.897    
-                         arrival time                           2.649    
+                         required time                         -2.860    
+                         arrival time                           2.568    
   -------------------------------------------------------------------
-                         slack                                 -0.249    
+                         slack                                 -0.293    
 
 
 

--- a/pyrpl/fpga/out/post_route_power.rpt
+++ b/pyrpl/fpga/out/post_route_power.rpt
@@ -1,16 +1,16 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-----------------------------------------------------------------------------------------
-| Tool Version     : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date             : Fri Mar 17 14:14:05 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+-------------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version     : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date             : Wed Feb 19 13:34:03 2025
 | Host             : fontana running 64-bit major release  (build 9200)
-| Command          : 
+| Command          : report_power -file out/post_route_power.rpt
 | Design           : red_pitaya_top
 | Device           : xc7z010clg400-1
 | Design State     : routed
 | Grade            : commercial
 | Process          : typical
 | Characterization : Production
-----------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Power Report
 
@@ -29,74 +29,76 @@ Table of Contents
 1. Summary
 ----------
 
-+--------------------------+-------+
-| Total On-Chip Power (W)  | 2.347 |
-| Dynamic (W)              | 2.194 |
-| Device Static (W)        | 0.153 |
-| Effective TJA (C/W)      | 11.5  |
-| Max Ambient (C)          | 57.9  |
-| Junction Temperature (C) | 52.1  |
-| Confidence Level         | Low   |
-| Setting File             | ---   |
-| Simulation Activity File | ---   |
-| Design Nets Matched      | NA    |
-+--------------------------+-------+
++--------------------------+--------------+
+| Total On-Chip Power (W)  | 2.250        |
+| Design Power Budget (W)  | Unspecified* |
+| Power Budget Margin (W)  | NA           |
+| Dynamic (W)              | 2.108        |
+| Device Static (W)        | 0.142        |
+| Effective TJA (C/W)      | 11.5         |
+| Max Ambient (C)          | 59.1         |
+| Junction Temperature (C) | 50.9         |
+| Confidence Level         | Low          |
+| Setting File             | ---          |
+| Simulation Activity File | ---          |
+| Design Nets Matched      | NA           |
++--------------------------+--------------+
+* Specify Design Power Budget using, set_operating_conditions -design_power_budget <value in Watts>
 
 
 1.1 On-Chip Components
 ----------------------
 
-+--------------------------+-----------+----------+-----------+-----------------+
-| On-Chip                  | Power (W) | Used     | Available | Utilization (%) |
-+--------------------------+-----------+----------+-----------+-----------------+
-| Clocks                   |     0.065 |       14 |       --- |             --- |
-| Slice Logic              |     0.130 |    36134 |       --- |             --- |
-|   LUT as Logic           |     0.113 |    16648 |     17600 |           94.59 |
-|   CARRY4                 |     0.011 |     1446 |      4400 |           32.86 |
-|   Register               |     0.005 |    14235 |     35200 |           40.44 |
-|   F7/F8 Muxes            |    <0.001 |      566 |     17600 |            3.22 |
-|   LUT as Shift Register  |    <0.001 |       63 |      6000 |            1.05 |
-|   Others                 |     0.000 |      407 |       --- |             --- |
-|   LUT as Distributed RAM |     0.000 |       24 |      6000 |            0.40 |
-| Signals                  |     0.180 |    28907 |       --- |             --- |
-| Block RAM                |     0.095 |       34 |        60 |           56.67 |
-| PLL                      |     0.097 |        1 |         2 |           50.00 |
-| DSPs                     |     0.044 |       46 |        80 |           57.50 |
-| I/O                      |     0.288 |       93 |       100 |           93.00 |
-| XADC                     |     0.004 |        1 |       --- |             --- |
-| PS7                      |     1.292 |        1 |       --- |             --- |
-| Static Power             |     0.153 |          |           |                 |
-| Total                    |     2.347 |          |           |                 |
-+--------------------------+-----------+----------+-----------+-----------------+
++-------------------------+-----------+----------+-----------+-----------------+
+| On-Chip                 | Power (W) | Used     | Available | Utilization (%) |
++-------------------------+-----------+----------+-----------+-----------------+
+| Clocks                  |     0.062 |       14 |       --- |             --- |
+| Slice Logic             |     0.115 |    34953 |       --- |             --- |
+|   LUT as Logic          |     0.099 |    16041 |     17600 |           91.14 |
+|   CARRY4                |     0.011 |     1458 |      4400 |           33.14 |
+|   Register              |     0.005 |    14204 |     35200 |           40.35 |
+|   F7/F8 Muxes           |    <0.001 |      556 |     17600 |            3.16 |
+|   LUT as Shift Register |    <0.001 |       43 |      6000 |            0.72 |
+|   Others                |     0.000 |      400 |       --- |             --- |
+| Signals                 |     0.157 |    28520 |       --- |             --- |
+| Block RAM               |     0.094 |       34 |        60 |           56.67 |
+| PLL                     |     0.097 |        1 |         2 |           50.00 |
+| DSPs                    |     0.044 |       46 |        80 |           57.50 |
+| I/O                     |     0.243 |       91 |       100 |           91.00 |
+| XADC                    |     0.004 |        1 |       --- |             --- |
+| PS7                     |     1.292 |        1 |       --- |             --- |
+| Static Power            |     0.142 |          |           |                 |
+| Total                   |     2.250 |          |           |                 |
++-------------------------+-----------+----------+-----------+-----------------+
 
 
 1.2 Power Supply Summary
 ------------------------
 
-+-----------+-------------+-----------+-------------+------------+
-| Source    | Voltage (V) | Total (A) | Dynamic (A) | Static (A) |
-+-----------+-------------+-----------+-------------+------------+
-| Vccint    |       1.000 |     0.522 |       0.512 |      0.011 |
-| Vccaux    |       1.800 |     0.069 |       0.057 |      0.012 |
-| Vcco33    |       3.300 |     0.085 |       0.084 |      0.001 |
-| Vcco25    |       2.500 |     0.001 |       0.000 |      0.001 |
-| Vcco18    |       1.800 |     0.002 |       0.001 |      0.001 |
-| Vcco15    |       1.500 |     0.001 |       0.000 |      0.001 |
-| Vcco135   |       1.350 |     0.000 |       0.000 |      0.000 |
-| Vcco12    |       1.200 |     0.000 |       0.000 |      0.000 |
-| Vccaux_io |       1.800 |     0.000 |       0.000 |      0.000 |
-| Vccbram   |       1.000 |     0.011 |       0.008 |      0.003 |
-| MGTAVcc   |       1.000 |     0.000 |       0.000 |      0.000 |
-| MGTAVtt   |       1.200 |     0.000 |       0.000 |      0.000 |
-| MGTVccaux |       1.800 |     0.000 |       0.000 |      0.000 |
-| Vccpint   |       1.000 |     0.717 |       0.678 |      0.039 |
-| Vccpaux   |       1.800 |     0.038 |       0.027 |      0.010 |
-| Vccpll    |       1.800 |     0.017 |       0.014 |      0.003 |
-| Vcco_ddr  |       1.500 |     0.356 |       0.354 |      0.002 |
-| Vcco_mio0 |       3.300 |     0.002 |       0.001 |      0.001 |
-| Vcco_mio1 |       2.500 |     0.003 |       0.002 |      0.001 |
-| Vccadc    |       1.800 |     0.022 |       0.002 |      0.020 |
-+-----------+-------------+-----------+-------------+------------+
++-----------+-------------+-----------+-------------+------------+-------------+-------------+------------+
+| Source    | Voltage (V) | Total (A) | Dynamic (A) | Static (A) | Powerup (A) | Budget (A)  | Margin (A) |
++-----------+-------------+-----------+-------------+------------+-------------+-------------+------------+
+| Vccint    |       1.000 |     0.484 |       0.473 |      0.010 |       NA    | Unspecified | NA         |
+| Vccaux    |       1.800 |     0.065 |       0.056 |      0.009 |       NA    | Unspecified | NA         |
+| Vcco33    |       3.300 |     0.070 |       0.069 |      0.001 |       NA    | Unspecified | NA         |
+| Vcco25    |       2.500 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vcco18    |       1.800 |     0.002 |       0.001 |      0.001 |       NA    | Unspecified | NA         |
+| Vcco15    |       1.500 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vcco135   |       1.350 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vcco12    |       1.200 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vccaux_io |       1.800 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vccbram   |       1.000 |     0.011 |       0.008 |      0.003 |       NA    | Unspecified | NA         |
+| MGTAVcc   |       1.000 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| MGTAVtt   |       1.200 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| MGTVccaux |       1.800 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vccpint   |       1.000 |     0.715 |       0.678 |      0.037 |       NA    | Unspecified | NA         |
+| Vccpaux   |       1.800 |     0.038 |       0.027 |      0.010 |       NA    | Unspecified | NA         |
+| Vccpll    |       1.800 |     0.017 |       0.014 |      0.003 |       NA    | Unspecified | NA         |
+| Vcco_ddr  |       1.500 |     0.356 |       0.354 |      0.002 |       NA    | Unspecified | NA         |
+| Vcco_mio0 |       3.300 |     0.002 |       0.001 |      0.001 |       NA    | Unspecified | NA         |
+| Vcco_mio1 |       2.500 |     0.003 |       0.002 |      0.001 |       NA    | Unspecified | NA         |
+| Vccadc    |       1.800 |     0.022 |       0.002 |      0.020 |       NA    | Unspecified | NA         |
++-----------+-------------+-----------+-------------+------------+-------------+-------------+------------+
 
 
 1.3 Confidence Level
@@ -147,7 +149,6 @@ Table of Contents
 | pll_dac_clk_2p | pll/clk_dac_2p                                                        |             4.0 |
 | pll_dac_clk_2x | pll/clk_dac_2x                                                        |             4.0 |
 | pll_pwm_clk    | pll/clk_pwm                                                           |             4.0 |
-| rx_clk         | daisy_p_i[1]                                                          |             4.0 |
 +----------------+-----------------------------------------------------------------------+-----------------+
 
 
@@ -157,221 +158,64 @@ Table of Contents
 3.1 By Hierarchy
 ----------------
 
-+----------------------------------------------------------------------------------+-----------+
-| Name                                                                             | Power (W) |
-+----------------------------------------------------------------------------------+-----------+
-| red_pitaya_top                                                                   |     2.194 |
-|   i_ams                                                                          |     0.002 |
-|   i_asg                                                                          |     0.060 |
-|     adv_trig_a                                                                   |     0.001 |
-|     adv_trig_b                                                                   |     0.002 |
-|     ch[0]                                                                        |     0.026 |
-|     ch[1]                                                                        |     0.026 |
-|     prng                                                                         |     0.001 |
-|   i_dsp                                                                          |     0.358 |
-|     dac_saturate[0]                                                              |     0.002 |
-|     dac_saturate[1]                                                              |     0.002 |
-|     genblk2[0].i_pid                                                             |     0.025 |
-|       pidfilter                                                                  |     0.014 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|         genblk2[1].lpf                                                           |     0.003 |
-|         genblk2[2].lpf                                                           |     0.004 |
-|         genblk2[3].lpf                                                           |     0.003 |
-|     genblk2[1].i_pid                                                             |     0.025 |
-|       pidfilter                                                                  |     0.014 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|         genblk2[1].lpf                                                           |     0.004 |
-|         genblk2[2].lpf                                                           |     0.004 |
-|         genblk2[3].lpf                                                           |     0.003 |
-|     genblk2[2].i_pid                                                             |     0.025 |
-|       pidfilter                                                                  |     0.014 |
-|         genblk2[0].lpf                                                           |     0.004 |
-|         genblk2[1].lpf                                                           |     0.004 |
-|         genblk2[2].lpf                                                           |     0.004 |
-|         genblk2[3].lpf                                                           |     0.004 |
-|     genblk3[3].i_trigger                                                         |     0.008 |
-|       triggerfilter                                                              |     0.004 |
-|         genblk2[0].lpf                                                           |     0.004 |
-|     genblk4[4].iir                                                               |     0.038 |
-|       iir_inputfilter                                                            |     0.002 |
-|         genblk2[0].lpf                                                           |     0.002 |
-|       p_ay1_module                                                               |     0.003 |
-|       p_ay2_module                                                               |    <0.001 |
-|       p_bx0_module                                                               |    <0.001 |
-|       p_bx1_module                                                               |     0.003 |
-|       s_dat_o_module                                                             |    <0.001 |
-|       s_y0_module                                                                |     0.006 |
-|     genblk5[5].iq                                                                |     0.062 |
-|       demodulator                                                                |     0.004 |
-|       inputfilter                                                                |     0.004 |
-|         genblk2[0].lpf                                                           |     0.004 |
-|       iq_fgen                                                                    |     0.016 |
-|       iqfilter[0]                                                                |     0.011 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.006 |
-|       iqfilter[1]                                                                |     0.010 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|       modulator                                                                  |     0.010 |
-|         firstproduct_saturation[0]                                               |     0.002 |
-|         firstproduct_saturation[1]                                               |     0.002 |
-|         i0_product_and_sat                                                       |     0.002 |
-|         sumsaturation                                                            |    <0.001 |
-|       pfd_block                                                                  |    <0.001 |
-|     genblk5[6].iq                                                                |     0.064 |
-|       demodulator                                                                |     0.004 |
-|       inputfilter                                                                |     0.004 |
-|         genblk2[0].lpf                                                           |     0.004 |
-|       iq_fgen                                                                    |     0.017 |
-|       iqfilter[0]                                                                |     0.011 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.006 |
-|       iqfilter[1]                                                                |     0.011 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.006 |
-|       modulator                                                                  |     0.010 |
-|         firstproduct_saturation[0]                                               |     0.002 |
-|         firstproduct_saturation[1]                                               |     0.002 |
-|         i0_product_and_sat                                                       |     0.002 |
-|         sumsaturation                                                            |    <0.001 |
-|       pfd_block                                                                  |    <0.001 |
-|     genblk6[7].iq_2_outputs                                                      |     0.087 |
-|       demodulator                                                                |     0.004 |
-|       inputfilter                                                                |     0.003 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|       iq_fgen                                                                    |     0.016 |
-|       iqfilter[0]                                                                |     0.020 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|         genblk2[2].lpf                                                           |     0.005 |
-|         genblk2[3].lpf                                                           |     0.006 |
-|       iqfilter[1]                                                                |     0.021 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|         genblk2[2].lpf                                                           |     0.005 |
-|         genblk2[3].lpf                                                           |     0.006 |
-|       modulator                                                                  |     0.013 |
-|         firstproduct_saturation[0]                                               |     0.002 |
-|         firstproduct_saturation[1]                                               |     0.002 |
-|         i0_product_and_sat                                                       |     0.002 |
-|         q0_product_and_sat                                                       |     0.002 |
-|         sumsaturation                                                            |    <0.001 |
-|       pfd_block                                                                  |    <0.001 |
-|   i_hk                                                                           |     0.001 |
-|   i_iobufn[0]                                                                    |    <0.001 |
-|   i_iobufn[1]                                                                    |    <0.001 |
-|   i_iobufn[2]                                                                    |    <0.001 |
-|   i_iobufn[3]                                                                    |    <0.001 |
-|   i_iobufn[4]                                                                    |    <0.001 |
-|   i_iobufn[5]                                                                    |    <0.001 |
-|   i_iobufn[6]                                                                    |    <0.001 |
-|   i_iobufn[7]                                                                    |    <0.001 |
-|   i_iobufp[0]                                                                    |    <0.001 |
-|   i_iobufp[1]                                                                    |    <0.001 |
-|   i_iobufp[2]                                                                    |    <0.001 |
-|   i_iobufp[3]                                                                    |    <0.001 |
-|   i_iobufp[4]                                                                    |    <0.001 |
-|   i_iobufp[5]                                                                    |    <0.001 |
-|   i_iobufp[6]                                                                    |    <0.001 |
-|   i_iobufp[7]                                                                    |    <0.001 |
-|   i_ps                                                                           |     1.323 |
-|     axi_master[0]                                                                |     0.001 |
-|       axi_awfifo_reg_0_15_30_35                                                  |    <0.001 |
-|       axi_awfifo_reg_0_15_36_36                                                  |    <0.001 |
-|       axi_wfifo_reg_0_15_60_65                                                   |    <0.001 |
-|     axi_master[1]                                                                |     0.001 |
-|       axi_awfifo_reg_0_15_30_35                                                  |    <0.001 |
-|       axi_awfifo_reg_0_15_36_36                                                  |    <0.001 |
-|       axi_wfifo_reg_0_15_60_65                                                   |    <0.001 |
-|     axi_slave_gp0                                                                |     0.004 |
-|     system_i                                                                     |     1.317 |
-|       system_i                                                                   |     1.317 |
-|         axi_protocol_converter_0                                                 |     0.014 |
-|           inst                                                                   |     0.014 |
-|             gen_axilite.gen_b2s_conv.axilite_b2s                                 |     0.014 |
-|               MI_REG                                                             |     0.000 |
-|                 ar_pipe                                                          |     0.000 |
-|                 aw_pipe                                                          |     0.000 |
-|                 axi_infrastructure_v1_1_0_axi2vector_0                           |     0.000 |
-|                 axi_infrastructure_v1_1_0_vector2axi_0                           |     0.000 |
-|                 b_pipe                                                           |     0.000 |
-|                 r_pipe                                                           |     0.000 |
-|                 w_pipe                                                           |     0.000 |
-|               RD.ar_channel_0                                                    |     0.003 |
-|                 ar_cmd_fsm_0                                                     |    <0.001 |
-|                 cmd_translator_0                                                 |     0.002 |
-|                   incr_cmd_0                                                     |    <0.001 |
-|                   wrap_cmd_0                                                     |     0.001 |
-|               RD.r_channel_0                                                     |     0.003 |
-|                 rd_data_fifo_0                                                   |     0.002 |
-|                 transaction_fifo_0                                               |    <0.001 |
-|               SI_REG                                                             |     0.004 |
-|                 ar_pipe                                                          |     0.001 |
-|                 aw_pipe                                                          |     0.001 |
-|                 axi_infrastructure_v1_1_0_axi2vector_0                           |     0.000 |
-|                 axi_infrastructure_v1_1_0_vector2axi_0                           |     0.000 |
-|                 b_pipe                                                           |    <0.001 |
-|                 r_pipe                                                           |     0.001 |
-|                 w_pipe                                                           |     0.000 |
-|               WR.aw_channel_0                                                    |     0.004 |
-|                 aw_cmd_fsm_0                                                     |    <0.001 |
-|                 cmd_translator_0                                                 |     0.003 |
-|                   incr_cmd_0                                                     |    <0.001 |
-|                   wrap_cmd_0                                                     |     0.001 |
-|               WR.b_channel_0                                                     |    <0.001 |
-|                 bid_fifo_0                                                       |    <0.001 |
-|                 bresp_fifo_0                                                     |    <0.001 |
-|         proc_sys_reset                                                           |    <0.001 |
-|           U0                                                                     |    <0.001 |
-|             EXT_LPF                                                              |    <0.001 |
-|               ACTIVE_LOW_EXT.ACT_LO_EXT                                          |    <0.001 |
-|             SEQ                                                                  |    <0.001 |
-|               SEQ_COUNTER                                                        |    <0.001 |
-|         processing_system7                                                       |     1.293 |
-|           inst                                                                   |     1.293 |
-|             xlnx_axi_wrshim_unwrap_inst_gp0                                      |     0.000 |
-|             xlnx_axi_wrshim_unwrap_inst_gp1                                      |     0.000 |
-|         xadc                                                                     |     0.009 |
-|           inst                                                                   |     0.009 |
-|             AXI_LITE_IPIF_I                                                      |     0.002 |
-|               I_SLAVE_ATTACHMENT                                                 |     0.002 |
-|                 I_DECODER                                                        |    <0.001 |
-|                   MEM_DECODE_GEN[0].GEN_FOR_MULTI_CS.MEM_SELECT_I                |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[0].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[1].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[2].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[3].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[4].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[5].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[6].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[7].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].GEN_FOR_MULTI_CS.MEM_SELECT_I                |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[0].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[10].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[11].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[12].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[13].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[14].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[15].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[1].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[2].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[3].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[4].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[5].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[6].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[7].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[8].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[9].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[2].GEN_FOR_MULTI_CS.MEM_SELECT_I                |    <0.001 |
-|             AXI_XADC_CORE_I                                                      |     0.005 |
-|             INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I                                 |     0.001 |
-|             SOFT_RESET_I                                                         |    <0.001 |
-|   i_scope                                                                        |     0.049 |
-|   pll                                                                            |     0.097 |
-|   pwm[0]                                                                         |     0.002 |
-|   pwm[1]                                                                         |     0.002 |
-|   pwm[2]                                                                         |     0.002 |
-|   pwm[3]                                                                         |     0.002 |
-+----------------------------------------------------------------------------------+-----------+
++-----------------------------+-----------+
+| Name                        | Power (W) |
++-----------------------------+-----------+
+| red_pitaya_top              |     2.108 |
+|   i_ams                     |     0.002 |
+|   i_asg                     |     0.059 |
+|     adv_trig_a              |     0.001 |
+|     ch[0]                   |     0.026 |
+|     ch[1]                   |     0.025 |
+|     prng                    |     0.001 |
+|   i_dsp                     |     0.332 |
+|     dac_saturate[0]         |     0.002 |
+|     dac_saturate[1]         |     0.002 |
+|     genblk2[0].i_pid        |     0.023 |
+|       pidfilter             |     0.012 |
+|     genblk2[1].i_pid        |     0.023 |
+|       pidfilter             |     0.012 |
+|     genblk2[2].i_pid        |     0.023 |
+|       pidfilter             |     0.012 |
+|     genblk3[3].i_trigger    |     0.006 |
+|       triggerfilter         |     0.003 |
+|     genblk4[4].iir          |     0.037 |
+|       iir_inputfilter       |     0.002 |
+|       p_ay1_module          |     0.003 |
+|       p_bx1_module          |     0.003 |
+|       s_y0_module           |     0.005 |
+|     genblk5[5].iq           |     0.059 |
+|       demodulator           |     0.003 |
+|       inputfilter           |     0.003 |
+|       iq_fgen               |     0.017 |
+|       iqfilter[0]           |     0.009 |
+|       iqfilter[1]           |     0.010 |
+|       modulator             |     0.010 |
+|     genblk5[6].iq           |     0.059 |
+|       demodulator           |     0.003 |
+|       inputfilter           |     0.003 |
+|       iq_fgen               |     0.017 |
+|       iqfilter[0]           |     0.009 |
+|       iqfilter[1]           |     0.010 |
+|       modulator             |     0.010 |
+|     genblk6[7].iq_2_outputs |     0.081 |
+|       demodulator           |     0.003 |
+|       inputfilter           |     0.003 |
+|       iq_fgen               |     0.016 |
+|       iqfilter[0]           |     0.019 |
+|       iqfilter[1]           |     0.019 |
+|       modulator             |     0.012 |
+|   i_hk                      |     0.001 |
+|   i_ps                      |     1.315 |
+|     axi_slave_gp0           |     0.004 |
+|     system_i                |     1.310 |
+|       system_i              |     1.310 |
+|   i_scope                   |     0.047 |
+|   pll                       |     0.097 |
+|   pwm[0]                    |     0.001 |
+|   pwm[1]                    |     0.001 |
+|   pwm[2]                    |     0.001 |
+|   pwm[3]                    |     0.001 |
++-----------------------------+-----------+
 
 

--- a/pyrpl/fpga/out/post_route_timing.rpt
+++ b/pyrpl/fpga/out/post_route_timing.rpt
@@ -1,791 +1,792 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-----------------------------------------------------------------------------------------------------------------
-| Tool Version : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date         : Fri Mar 17 14:13:55 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:33:45 2025
 | Host         : fontana running 64-bit major release  (build 9200)
 | Command      : report_timing -file out/post_route_timing.rpt -sort_by group -max_paths 100 -path_type summary
 | Design       : red_pitaya_top
 | Device       : 7z010-clg400
-| Speed File   : -1  PRODUCTION 1.11 2014-09-11
-----------------------------------------------------------------------------------------------------------------
+| Speed File   : -1  PRODUCTION 1.12 2019-11-22
+| Design State : Routed
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Timing Report
 
 Startpoint                     Endpoint                       Slack(ns)     
 ----------------------------------------------------------------------------
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
                                i_dsp/genblk4[4].iir/overflow_reg[3]/D
-                                                              -5.896        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[15]/D
-                                                              -5.692        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[24]/D
-                                                              -5.666        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[19]/D
-                                                              -5.661        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[21]/D
-                                                              -5.634        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[0]/D
-                                                              -5.607        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[30]/D
-                                                              -5.604        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[25]/D
-                                                              -5.595        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[16]/D
-                                                              -5.544        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[11]/D
-                                                              -5.544        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[12]/D
-                                                              -5.544        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[1]/D
-                                                              -5.513        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[20]/D
-                                                              -5.511        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[2]/D
-                                                              -5.485        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[18]/D
-                                                              -5.482        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[9]/D
-                                                              -5.481        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[4]/D
-                                                              -5.480        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[29]/D
-                                                              -5.471        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[22]/D
-                                                              -5.467        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[17]/D
-                                                              -5.461        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[8]/D
-                                                              -5.457        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[7]/D
-                                                              -5.442        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[13]/D
-                                                              -5.440        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[14]/D
-                                                              -5.437        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[6]/D
-                                                              -5.432        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[26]/D
-                                                              -5.430        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[23]/D
-                                                              -5.429        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[5]/D
-                                                              -5.387        
-i_dsp/genblk4[4].iir/b1_reg[6]/C
-                               i_dsp/genblk4[4].iir/overflow_reg[4]/D
-                                                              -5.383        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[28]/D
-                                                              -5.371        
-i_dsp/genblk4[4].iir/y1a_reg[9]/C
-                               i_dsp/genblk4[4].iir/overflow_reg[0]/D
-                                                              -5.366        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[10]/D
-                                                              -5.328        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[3]/D
-                                                              -5.324        
-i_dsp/genblk4[4].iir/x0b_reg[15]/C
-                               i_dsp/genblk4[4].iir/p_bx0_reg[27]/D
-                                                              -5.321        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/overflow_reg[1]/D
-                                                              -5.221        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[6]
-                                                              -5.117        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[10]
-                                                              -5.032        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[4]
-                                                              -4.959        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[12]/D
-                                                              -4.942        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[0]/D
-                                                              -4.940        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[11]/D
-                                                              -4.938        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[7]
-                                                              -4.937        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[2]
-                                                              -4.930        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[12]
-                                                              -4.914        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[2]/D
-                                                              -4.912        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[1]
-                                                              -4.911        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[9]
-                                                              -4.908        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[0]
-                                                              -4.908        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[30]/D
-                                                              -4.863        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[3]/D
-                                                              -4.854        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[4]/D
-                                                              -4.852        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[3]
-                                                              -4.842        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[27]/D
-                                                              -4.839        
-i_dsp/genblk5[5].iq/demodulator/product1_reg/CLK
-                               i_dsp/genblk5[5].iq/modulator/secondproduct1/D[12]
-                                                              -4.828        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[19]/D
-                                                              -4.813        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[26]/D
-                                                              -4.793        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[2]/D
-                                                              -4.790        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
+                                                              -4.965        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
                                i_dsp/genblk4[4].iir/p_ay2_reg[24]/D
-                                                              -4.789        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[29]/D
-                                                              -4.789        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[6]/D
-                                                              -4.788        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[15]/D
-                                                              -4.785        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[10]/D
-                                                              -4.783        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[13]/D
-                                                              -4.780        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[10]/D
-                                                              -4.772        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[23]/D
-                                                              -4.762        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[25]/D
-                                                              -4.757        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[7]/D
-                                                              -4.756        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[20]/D
-                                                              -4.741        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[5]/D
-                                                              -4.727        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[21]/D
-                                                              -4.726        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[9]/D
-                                                              -4.725        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[22]/D
-                                                              -4.708        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[8]
-                                                              -4.693        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[28]/D
-                                                              -4.676        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[4]/D
-                                                              -4.655        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[3]/D
-                                                              -4.645        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[1]/D
-                                                              -4.644        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[5]
-                                                              -4.638        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[12]/D
-                                                              -4.628        
-i_dsp/genblk5[5].iq/demodulator/product1_reg/CLK
-                               i_dsp/genblk5[5].iq/modulator/secondproduct1/D[4]
-                                                              -4.612        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[9]/D
-                                                              -4.609        
-i_dsp/genblk5[5].iq/demodulator/product1_reg/CLK
-                               i_dsp/genblk5[5].iq/modulator/secondproduct1/D[10]
-                                                              -4.608        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[8]/D
-                                                              -4.605        
-i_dsp/genblk6[7].iq_2_outputs/demodulator/product1_reg/CLK
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[11]
-                                                              -4.603        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[18]/D
-                                                              -4.584        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[17]/D
-                                                              -4.581        
-i_dsp/genblk4[4].iir/y1a_reg[9]/C
-                               i_dsp/genblk4[4].iir/p_ay1_reg[8]/D
-                                                              -4.580        
-i_dsp/genblk4[4].iir/y1a_reg[10]/C
-                               i_dsp/genblk4[4].iir/p_ay1_reg[15]/D
-                                                              -4.578        
-i_dsp/genblk5[5].iq/demodulator/product1_reg/CLK
-                               i_dsp/genblk5[5].iq/modulator/secondproduct1/D[7]
-                                                              -4.568        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[1]/D
-                                                              -4.561        
-i_dsp/genblk4[4].iir/y1a_reg[9]/C
-                               i_dsp/genblk4[4].iir/p_ay1_reg[30]/D
-                                                              -4.552        
-i_dsp/genblk4[4].iir/y1a_reg[9]/C
-                               i_dsp/genblk4[4].iir/p_ay1_reg[10]/D
-                                                              -4.550        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[0]/D
-                                                              -4.528        
-i_dsp/genblk4[4].iir/y1a_reg[10]/C
-                               i_dsp/genblk4[4].iir/p_ay1_reg[11]/D
-                                                              -4.526        
-i_dsp/genblk4[4].iir/y1a_reg[10]/C
-                               i_dsp/genblk4[4].iir/p_ay1_reg[16]/D
-                                                              -4.521        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
+                                                              -4.901        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[3]/D
+                                                              -4.837        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
                                i_dsp/genblk4[4].iir/p_ay2_reg[8]/D
-                                                              -4.517        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[7]/D
-                                                              -4.516        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
-                               i_dsp/genblk4[4].iir/p_ay2_reg[14]/D
-                                                              -4.516        
-i_dsp/genblk6[7].iq_2_outputs/quadrature_filter_reg[7]/C
-                               i_dsp/genblk6[7].iq_2_outputs/modulator/q2_product_reg_reg[5]/D
-                                                              -4.509        
-i_dsp/genblk4[4].iir/y2a_reg[1]/C
+                                                              -4.815        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[15]/D
+                                                              -4.804        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[11]/D
+                                                              -4.802        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[4]/D
+                                                              -4.799        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[8]/D
+                                                              -4.787        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[8]/D
+                                                              -4.783        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[2]
+                                                              -4.781        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
                                i_dsp/genblk4[4].iir/p_ay2_reg[16]/D
-                                                              -4.506        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/D
-                                                              -2.193        
+                                                              -4.780        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[9]
+                                                              -4.777        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[30]/D
+                                                              -4.774        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[22]/D
+                                                              -4.773        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[10]
+                                                              -4.768        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[8]
+                                                              -4.764        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[6]/D
+                                                              -4.755        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[0]/D
+                                                              -4.755        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[1]
+                                                              -4.754        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[0]/D
+                                                              -4.752        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[5]/D
+                                                              -4.752        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[4]
+                                                              -4.751        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[19]/D
+                                                              -4.749        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[7]
+                                                              -4.749        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[6]/D
+                                                              -4.738        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[7]/D
+                                                              -4.738        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/overflow_reg[0]/D
+                                                              -4.727        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[18]/D
+                                                              -4.723        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[7]/D
+                                                              -4.720        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[26]/D
+                                                              -4.720        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[17]/D
+                                                              -4.720        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[26]/D
+                                                              -4.719        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[25]/D
+                                                              -4.717        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[22]/D
+                                                              -4.703        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[6]/D
+                                                              -4.700        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[5]/D
+                                                              -4.670        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[7]/D
+                                                              -4.664        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[29]/D
+                                                              -4.664        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[30]/D
+                                                              -4.663        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[30]/D
+                                                              -4.662        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[10]/D
+                                                              -4.661        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[4]/D
+                                                              -4.659        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[9]/D
+                                                              -4.657        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[24]/D
+                                                              -4.654        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[21]/D
+                                                              -4.654        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[26]/D
+                                                              -4.652        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[10]/D
+                                                              -4.651        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[9]/D
+                                                              -4.651        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[15]/D
+                                                              -4.650        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[28]/D
+                                                              -4.647        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[27]/D
+                                                              -4.645        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[16]/D
+                                                              -4.644        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[0]/D
+                                                              -4.643        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[2]/D
+                                                              -4.643        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[27]/D
+                                                              -4.642        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[19]/D
+                                                              -4.641        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[28]/D
+                                                              -4.630        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[12]/D
+                                                              -4.629        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[18]/D
+                                                              -4.627        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[22]/D
+                                                              -4.625        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[13]/D
+                                                              -4.622        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[23]/D
+                                                              -4.617        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[29]/D
+                                                              -4.615        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[12]
+                                                              -4.611        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[6]
+                                                              -4.610        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[18]/D
+                                                              -4.609        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[5]
+                                                              -4.607        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[2]/D
+                                                              -4.603        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[11]
+                                                              -4.602        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[28]/D
+                                                              -4.597        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[24]/D
+                                                              -4.593        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[3]/D
+                                                              -4.584        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[1]/D
+                                                              -4.584        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[1]/D
+                                                              -4.580        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[19]/D
+                                                              -4.578        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[14]/D
+                                                              -4.578        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[10]/D
+                                                              -4.576        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[21]/D
+                                                              -4.576        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[9]/D
+                                                              -4.573        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[11]/D
+                                                              -4.573        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[4]/D
+                                                              -4.572        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[29]/D
+                                                              -4.571        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/overflow_reg[4]/D
+                                                              -4.571        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[11]/D
+                                                              -4.570        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/overflow_reg[1]/D
+                                                              -4.570        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[20]/D
+                                                              -4.570        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[17]/D
+                                                              -4.569        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[23]/D
+                                                              -4.567        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[21]/D
+                                                              -4.563        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[12]/D
+                                                              -4.561        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[3]/D
+                                                              -4.561        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[2]/D
+                                                              -4.547        
+i_dsp/genblk6[7].iq_2_outputs/iqfilter[1]/genblk2[0].lpf/y_reg[34]/C
+                               i_dsp/genblk6[7].iq_2_outputs/modulator/secondproduct1/D[3]
+                                                              -4.546        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[14]/D
+                                                              -4.544        
+i_dsp/genblk4[4].iir/a1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_ay1_reg[28]/D
+                                                              -4.538        
+i_dsp/genblk4[4].iir/y2a_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_ay2_reg[29]/D
+                                                              -4.536        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[5]/D
+                                                              -4.532        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[25]/D
+                                                              -4.518        
+i_dsp/genblk4[4].iir/b1_reg[14]/C
+                               i_dsp/genblk4[4].iir/p_bx1_reg[13]/D
+                                                              -4.510        
+i_dsp/genblk4[4].iir/x0b_reg[16]/C
+                               i_dsp/genblk4[4].iir/p_bx0_reg[14]/D
+                                                              -4.509        
+pwm[0]/v_r_reg[1]/C            pwm[0]/pwm_o_reg/D             -0.406        
+pwm[1]/v_r_reg[3]/C            pwm[1]/pwm_o_reg/D             -0.385        
+pwm[2]/v_r_reg[0]/C            pwm[2]/pwm_o_reg/D             -0.302        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[3]
+                                                              -0.216        
+pwm[3]/vcnt_r_reg[7]/C         pwm[3]/pwm_o_reg/D             -0.212        
 i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/D
-                                                              -1.782        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/D
-                                                              -1.488        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[16]/CE
-                                                              -1.464        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[20]/CE
-                                                              -1.464        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[28]/CE
-                                                              -1.464        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[15]/CE
-                                                              -1.421        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[19]/CE
-                                                              -1.421        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[24]/CE
-                                                              -1.421        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[26]/CE
-                                                              -1.421        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[3]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[20].ce_out_i_reg[20]/D
-                                                              -1.394        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[10]/D
-                                                              -1.393        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_second_len_r_reg[0]/D
-                                                              -1.385        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]/D
-                                                              -1.377        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_fifo_0/cnt_read_reg[1]/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[14]/CE
-                                                              -1.370        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/ar_cmd_fsm_0/state_reg[0]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_second_len_r_reg[0]/D
-                                                              -1.358        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[2]/D
-                                                              -1.347        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[17]/CE
-                                                              -1.331        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[21]/CE
-                                                              -1.331        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[27]/CE
-                                                              -1.331        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[7]/D
-                                                              -1.243        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[1]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[2]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[5]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[6]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[7]/CE
-                                                              -1.217        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[3]/CE
-                                                              -1.210        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
                                i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[0]/CE
-                                                              -1.209        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[1]/D
-                                                              -1.197        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[23]/CE
-                                                              -1.190        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[29]/CE
-                                                              -1.190        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[31]/CE
-                                                              -1.190        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[30]/CE
-                                                              -1.189        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[6]/D
-                                                              -1.183        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[23].ce_out_i_reg[23]/D
-                                                              -1.181        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[9]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[7].ce_out_i_reg[7]/D
-                                                              -1.178        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
+                                                              -0.132        
+i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
                                i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[1]/CE
-                                                              -1.171        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
+                                                              -0.132        
+i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
                                i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[2]/CE
-                                                              -1.171        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[3]/CE
-                                                              -1.171        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[0]/CE
-                                                              -1.171        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[10]/CE
-                                                              -1.169        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]/CE
-                                                              -1.169        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/CE
-                                                              -1.169        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[3]/CE
-                                                              -1.167        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[10]/CE
-                                                              -1.166        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[7]/CE
-                                                              -1.166        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[9]/CE
-                                                              -1.166        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/s_axburst_eq0_reg/CE
-                                                              -1.163        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/s_axburst_eq1_reg/CE
-                                                              -1.163        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[1]/CE
-                                                              -1.163        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[2]/CE
-                                                              -1.163        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[4]/CE
-                                                              -1.163        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/sel_first_reg/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[5].ce_out_i_reg[5]/D
-                                                              -1.133        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/sel_first_reg/C
+                                                              -0.132        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
                                i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[1].ce_out_i_reg[1]/D
-                                                              -1.130        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[3]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[1]
-                                                              -1.104        
-i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/D
-                                                              -1.102        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[18]/CE
-                                                              -1.090        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[22]/CE
-                                                              -1.090        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]_rep__2/C
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[25]/CE
-                                                              -1.090        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[5]/D
-                                                              -1.089        
+                                                              -0.115        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/s_axburst_eq0_reg/CE
+                                                              -0.070        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/s_axburst_eq1_reg/CE
+                                                              -0.070        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_fifo_0/memory_reg[3][1]_srl4/CE
+                                                              -0.046        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]/D
+                                                              -0.024        
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/s_axburst_eq0_reg/D
+                                                              -0.015        
 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[11].ce_out_i_reg[11]/D
-                                                              -1.068        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/sel_first_reg/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[16].ce_out_i_reg[16]/D
-                                                              -1.065        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[19].ce_out_i_reg[19]/D
-                                                              -1.058        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[3]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[15].ce_out_i_reg[15]/D
-                                                              -1.057        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[12].ce_out_i_reg[12]/D
-                                                              -1.056        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[3]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[10].ce_out_i_reg[10]/D
-                                                              -1.050        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[14].ce_out_i_reg[14]/D
-                                                              -1.049        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[8].ce_out_i_reg[8]/D
-                                                              -1.039        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/axaddr_wrap_reg[6]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[9].ce_out_i_reg[9]/D
-                                                              -1.032        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[2]/D
-                                                              -1.028        
-i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[10]/D
-                                                              -1.018        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/state_reg[1]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[3]/D
-                                                              -1.017        
-i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]/D
-                                                              -0.998        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awid_r_reg[11]/CE
-                                                              -0.980        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awid_r_reg[7]/CE
-                                                              -0.980        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awid_r_reg[8]/CE
-                                                              -0.980        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]/D
-                                                              -0.978        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[9]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[4].ce_out_i_reg[4]/D
-                                                              -0.976        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[1]/CE
-                                                              -0.954        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[9]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[4]
+                                                              0.009         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
                                i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[6].ce_out_i_reg[6]/D
-                                                              -0.953        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[9]/C
+                                                              0.013         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
                                i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[0].ce_out_i_reg[0]/D
-                                                              -0.951        
+                                                              0.015         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[4]/CE
+                                                              0.020         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/s_axburst_eq1_reg/D
+                                                              0.037         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[5]/D
+                                                              0.038         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[1]/CE
+                                                              0.039         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[2]/CE
+                                                              0.039         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[3]/CE
+                                                              0.039         
 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/sel_first_reg/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[13].ce_out_i_reg[13]/D
-                                                              -0.948        
+                               i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[2]
+                                                              0.039         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[4].ce_out_i_reg[4]/D
+                                                              0.044         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[0]/CE
+                                                              0.044         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[1]/CE
+                                                              0.044         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[2]/CE
+                                                              0.044         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]/D
+                                                              0.047         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[12].ce_out_i_reg[12]/D
+                                                              0.048         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[5].ce_out_i_reg[5]/D
+                                                              0.048         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[9].ce_out_i_reg[9]/D
+                                                              0.055         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/s_bresp_acc_reg[1]/CE
+                                                              0.059         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[3]/D
+                                                              0.060         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]/CE
+                                                              0.086         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[3]/CE
+                                                              0.086         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/ar_cmd_fsm_0/FSM_sequential_state_reg[0]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[6]
+                                                              0.088         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw.aw_pipe/m_payload_i_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[2]/D
+                                                              0.088         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[0]/CE
+                                                              0.093         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[8]/CE
+                                                              0.093         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/sel_first_reg/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[1]
+                                                              0.099         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[7].ce_out_i_reg[7]/D
+                                                              0.106         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/next_pending_r_reg/D
+                                                              0.110         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/CE
+                                                              0.122         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_second_len_r_reg[2]/D
+                                                              0.125         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/bcnt_reg[0]/CE          0.158         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/bcnt_reg[1]/CE          0.158         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/bcnt_reg[2]/CE          0.158         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/bcnt_reg[3]/CE          0.158         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[2].ce_out_i_reg[2]/D
+                                                              0.159         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[3].ce_out_i_reg[3]/D
+                                                              0.164         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[2]/D
+                                                              0.165         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[3]/CE
+                                                              0.167         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[7]/CE
+                                                              0.167         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/D
+                                                              0.169         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[22].ce_out_i_reg[22]/D
+                                                              0.173         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]/CE
+                                                              0.187         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[1]/CE
+                                                              0.187         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[2]/CE
+                                                              0.187         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]/CE
+                                                              0.187         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[19].ce_out_i_reg[19]/D
+                                                              0.193         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_second_len_r_reg[1]/D
+                                                              0.195         
 i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
                                i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_wrack_reg/D
-                                                              -0.935        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar_pipe/m_payload_i_reg[9]/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[3].ce_out_i_reg[3]/D
-                                                              -0.930        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/sel_first_reg/C
-                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[2].ce_out_i_reg[2]/D
-                                                              -0.919        
+                                                              0.210         
+pwm_rstn_reg/C                 pwm[2]/pwm_o_reg/R             0.211         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[7]/D
+                                                              0.222         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[0]/CE
+                                                              0.226         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[3]/CE
+                                                              0.226         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[14].ce_out_i_reg[14]/D
+                                                              0.226         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[1]/CE
+                                                              0.236         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[21].ce_out_i_reg[21]/D
+                                                              0.237         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[3]/CE
+                                                              0.238         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[5]/CE
+                                                              0.238         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[8]/CE
+                                                              0.238         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[0]/R
+                                                              0.246         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[5]/R
+                                                              0.246         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[6]/R
+                                                              0.246         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[7]/R
+                                                              0.246         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[15].GEN_REG_STATUS.ip_irpt_status_reg_reg[15]/D
+                                                              0.249         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/bcnt_reg[0]/CE          0.253         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/bcnt_reg[1]/CE          0.253         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/bcnt_reg[2]/CE          0.253         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/bcnt_reg[3]/CE          0.253         
 i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[7]/D
-                                                              -0.888        
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[4]/CE
+                                                              0.261         
+i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[5]/CE
+                                                              0.261         
+i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[6]/CE
+                                                              0.261         
+i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_rdack_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[7]/CE
+                                                              0.261         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/bcnt_reg[0]/CE          0.264         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/bcnt_reg[1]/CE          0.264         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/bcnt_reg[2]/CE          0.264         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/bcnt_reg[3]/CE          0.264         
 i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.ip2bus_data_int_reg[22]/D
-                                                              -0.877        
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[0]/CE
+                                                              0.272         
 i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
-                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[10].GEN_REG_STATUS.ip_irpt_status_reg_reg[10]/D
-                                                              -0.847        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awid_r_reg[4]/CE
-                                                              -0.843        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awlen_r_reg[0]/CE
-                                                              -0.837        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awlen_r_reg[1]/CE
-                                                              -0.837        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awlen_r_reg[2]/CE
-                                                              -0.837        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/s_awlen_r_reg[3]/CE
-                                                              -0.837        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[11]/CE
-                                                              -0.831        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[5]/CE
-                                                              -0.831        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[6]/CE
-                                                              -0.831        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[0]_rep__0/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/s_arid_r_reg[8]/CE
-                                                              -0.831        
-i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
-                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axlen_cnt_reg[5]/CE
-                                                              -0.826        
-pwm[0]/vcnt_r_reg[0]/C         pwm[0]/pwm_o_reg/D             -0.724        
-pwm[1]/v_r_reg[3]/C            pwm[1]/pwm_o_reg/D             -0.567        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[0]/CE             -0.567        
-pwm_rstn_reg/C                 pwm[2]/pwm_o_reg/R             -0.401        
-pwm[2]/vcnt_r_reg[4]/C         pwm[2]/pwm_o_reg/D             -0.372        
-pwm[3]/v_r_reg[6]/C            pwm[3]/pwm_o_reg/D             -0.351        
-pwm_rstn_reg/C                 pwm[0]/pwm_o_reg/R             -0.320        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[7]/CE             -0.266        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[8]/CE             -0.266        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[12]/CE            -0.111        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[13]/CE            -0.111        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[1]/CE             -0.111        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[2]/CE             -0.111        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[10]/CE            -0.027        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[11]/CE            -0.027        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[14]/CE            -0.027        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[9]/CE             -0.027        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[15]/CE            -0.021        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[3]/CE             -0.021        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[4]/CE             -0.021        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[5]/CE             -0.021        
-pwm[2]/vcnt_reg[0]/C           pwm[2]/b_reg[6]/CE             -0.021        
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[0]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[1]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[2]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[3]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[4]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[5]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[6]/CE             0.055         
-pwm[0]/bcnt_reg[3]/C           pwm[0]/v_reg[7]/CE             0.055         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[3]/CE             0.064         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[8]/CE             0.068         
-pwm[2]/vcnt_reg[0]/C           pwm[2]/bcnt_reg[0]/CE          0.102         
-pwm[2]/vcnt_reg[0]/C           pwm[2]/bcnt_reg[1]/CE          0.102         
-pwm[2]/vcnt_reg[0]/C           pwm[2]/bcnt_reg[2]/CE          0.102         
-pwm[2]/vcnt_reg[0]/C           pwm[2]/bcnt_reg[3]/CE          0.102         
-pwm[3]/vcnt_reg[3]/C           pwm[3]/b_reg[0]/CE             0.147         
-pwm[3]/vcnt_reg[3]/C           pwm[3]/b_reg[12]/CE            0.147         
-pwm[3]/vcnt_reg[3]/C           pwm[3]/b_reg[13]/CE            0.147         
-pwm[3]/vcnt_reg[3]/C           pwm[3]/b_reg[14]/CE            0.147         
-pwm_rstn_reg/C                 pwm[1]/vcnt_reg[5]/R           0.152         
-pwm[2]/b_reg[0]/C              pwm[2]/v_r_reg[7]/D            0.207         
-pwm[2]/b_reg[0]/C              pwm[2]/v_r_reg[5]/D            0.209         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[0]/CE             0.220         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[1]/CE             0.220         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[2]/CE             0.220         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[5]/CE             0.220         
-pwm_rstn_reg/C                 pwm[3]/pwm_o_reg/R             0.220         
-pwm_rstn_reg/C                 pwm[2]/bcnt_reg[0]/R           0.236         
-pwm_rstn_reg/C                 pwm[2]/bcnt_reg[1]/R           0.236         
-pwm_rstn_reg/C                 pwm[2]/bcnt_reg[2]/R           0.236         
-pwm_rstn_reg/C                 pwm[2]/bcnt_reg[3]/R           0.236         
-pwm_rstn_reg/C                 pwm[1]/pwm_o_reg/R             0.239         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[0]/CE           0.246         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[1]/CE           0.246         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[2]/CE           0.246         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[3]/CE           0.246         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[4]/CE           0.246         
-pwm_rstn_reg/C                 pwm[2]/vcnt_r_reg[0]/CE        0.246         
-pwm_rstn_reg/C                 pwm[2]/vcnt_r_reg[6]/CE        0.246         
-pwm[2]/b_reg[0]/C              pwm[2]/v_r_reg[8]/D            0.256         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[0]/CE             0.260         
-pwm[2]/b_reg[0]/C              pwm[2]/v_r_reg[6]/D            0.261         
-i_ams/dac_c_o_reg[8]/C         pwm[2]/b_reg[8]/D              0.272         
-i_ams/dac_a_o_reg[5]/C         pwm[0]/b_reg[5]/D              0.284         
-pwm[0]/vcnt_reg[4]/C           pwm[0]/bcnt_reg[0]/CE          0.286         
-pwm[0]/vcnt_reg[4]/C           pwm[0]/bcnt_reg[1]/CE          0.286         
-pwm[0]/vcnt_reg[4]/C           pwm[0]/bcnt_reg[2]/CE          0.286         
-pwm[0]/vcnt_reg[4]/C           pwm[0]/bcnt_reg[3]/CE          0.286         
-i_ams/dac_d_o_reg[2]/C         pwm[3]/b_reg[2]/D              0.299         
-pwm_rstn_reg/C                 pwm[0]/bcnt_reg[0]/R           0.322         
-pwm_rstn_reg/C                 pwm[0]/bcnt_reg[1]/R           0.322         
-pwm_rstn_reg/C                 pwm[0]/bcnt_reg[2]/R           0.322         
-pwm_rstn_reg/C                 pwm[0]/bcnt_reg[3]/R           0.322         
-i_ams/dac_c_o_reg[15]/C        pwm[2]/b_reg[15]/D             0.327         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[4]/CE             0.360         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[6]/CE             0.360         
-pwm[1]/bcnt_reg[1]/C           pwm[1]/v_reg[7]/CE             0.360         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[1]/CE             0.360         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[2]/CE             0.360         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[3]/CE             0.360         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[4]/CE             0.360         
-i_ams/dac_a_o_reg[8]/C         pwm[0]/b_reg[8]/D              0.363         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[5]/CE             0.364         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[6]/CE             0.364         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[7]/CE             0.364         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[9]/CE             0.364         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[5]/CE           0.364         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[6]/CE           0.364         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[7]/CE           0.364         
-pwm_rstn_reg/C                 pwm[2]/v_r_reg[8]/CE           0.364         
-pwm_rstn_reg/C                 pwm[2]/vcnt_r_reg[3]/CE        0.364         
-pwm_rstn_reg/C                 pwm[2]/vcnt_r_reg[7]/CE        0.364         
-i_ams/dac_b_o_reg[14]/C        pwm[1]/b_reg[14]/D             0.377         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[10]/CE            0.380         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[11]/CE            0.380         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[12]/CE            0.380         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[13]/CE            0.380         
-pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[14]/CE            0.380         
-pwm_rstn_reg/C                 pwm[0]/vcnt_reg[3]/R           0.386         
-dac_rst_reg/C                  oddr_dac_dat[13]/R             0.538         
-dac_rst_reg/C                  oddr_dac_dat[2]/R              0.565         
-dac_rst_reg/C                  oddr_dac_dat[6]/R              0.661         
-dac_rst_reg/C                  oddr_dac_dat[4]/R              0.662         
-dac_rst_reg/C                  oddr_dac_dat[12]/R             0.676         
-dac_rst_reg/C                  oddr_dac_dat[3]/R              0.703         
-dac_rst_reg/C                  oddr_dac_dat[0]/R              0.727         
-dac_rst_reg/C                  oddr_dac_dat[7]/R              0.802         
-dac_rst_reg/C                  oddr_dac_dat[5]/R              0.802         
-dac_rst_reg/C                  oddr_dac_dat[1]/R              0.865         
-dac_rst_reg/C                  oddr_dac_dat[8]/R              0.954         
-dac_rst_reg/C                  oddr_dac_dat[10]/R             0.999         
-dac_rst_reg/C                  oddr_dac_dat[9]/R              1.104         
-dac_rst_reg/C                  oddr_dac_dat[11]/R             1.138         
-dac_rst_reg/C                  oddr_dac_sel/R                 1.192         
-dac_dat_a_reg[4]/C             oddr_dac_dat[4]/D2             1.642         
-dac_dat_a_reg[8]/C             oddr_dac_dat[8]/D2             1.801         
-dac_dat_a_reg[12]/C            oddr_dac_dat[12]/D2            1.849         
-dac_dat_a_reg[2]/C             oddr_dac_dat[2]/D2             1.855         
-dac_dat_a_reg[13]/C            oddr_dac_dat[13]/D2            1.863         
-dac_dat_a_reg[9]/C             oddr_dac_dat[9]/D2             1.884         
-dac_dat_a_reg[1]/C             oddr_dac_dat[1]/D2             1.902         
-dac_dat_a_reg[0]/C             oddr_dac_dat[0]/D2             1.904         
-dac_dat_a_reg[3]/C             oddr_dac_dat[3]/D2             1.904         
-dac_dat_a_reg[7]/C             oddr_dac_dat[7]/D2             1.981         
-dac_rst_reg/C                  oddr_dac_rst/D2                2.022         
-dac_dat_a_reg[11]/C            oddr_dac_dat[11]/D2            2.043         
-dac_dat_a_reg[6]/C             oddr_dac_dat[6]/D2             2.129         
-dac_dat_a_reg[10]/C            oddr_dac_dat[10]/D2            2.192         
-dac_dat_a_reg[5]/C             oddr_dac_dat[5]/D2             2.192         
-i_dsp/sum1_reg[13]/C           dac_dat_a_reg[0]/D             3.061         
-i_dsp/sum1_reg[16]/C           dac_dat_a_reg[5]/D             3.227         
-i_dsp/sum1_reg[13]/C           dac_dat_a_reg[2]/D             3.238         
-i_dsp/sum2_reg[13]/C           dac_dat_b_reg[1]/D             3.410         
-i_dsp/sum2_reg[12]/C           dac_dat_b_reg[12]/D            3.434         
-i_dsp/sum2_reg[14]/C           dac_dat_b_reg[10]/D            3.539         
-i_dsp/sum1_reg[14]/C           dac_dat_a_reg[3]/D             3.561         
-i_dsp/sum2_reg[13]/C           dac_dat_b_reg[3]/D             3.566         
-i_dsp/sum1_reg[13]/C           dac_dat_a_reg[1]/D             3.592         
-i_dsp/sum2_reg[15]/C           dac_dat_b_reg[0]/D             3.671         
-i_dsp/sum1_reg[16]/C           dac_dat_a_reg[12]/D            3.701         
-i_dsp/sum2_reg[13]/C           dac_dat_b_reg[2]/D             3.773         
-i_dsp/sum1_reg[11]/C           dac_dat_a_reg[11]/D            3.811         
-i_dsp/sum1_reg[14]/C           dac_dat_a_reg[4]/D             3.923         
-i_dsp/sum1_reg[14]/C           dac_dat_a_reg[7]/D             3.950         
-i_dsp/sum1_reg[14]/C           dac_dat_a_reg[10]/D            4.021         
-i_dsp/sum2_reg[14]/C           dac_dat_b_reg[5]/D             4.023         
-i_dsp/sum2_reg[13]/C           dac_dat_b_reg[8]/D             4.083         
-i_dsp/sum1_reg[6]/C            dac_dat_a_reg[6]/D             4.160         
-i_dsp/sum1_reg[14]/C           dac_dat_a_reg[8]/D             4.266         
-i_dsp/sum2_reg[16]/C           dac_dat_b_reg[4]/D             4.320         
-i_dsp/sum2_reg[15]/C           dac_dat_b_reg[6]/D             4.405         
-i_dsp/sum1_reg[9]/C            dac_dat_a_reg[9]/D             4.502         
-i_dsp/sum2_reg[15]/C           dac_dat_b_reg[9]/D             4.512         
-i_dsp/sum2_reg[13]/C           dac_dat_b_reg[7]/D             4.515         
-i_dsp/sum1_reg[17]/C           dac_dat_a_reg[13]/D            4.582         
-i_dsp/sum2_reg[13]/C           dac_dat_b_reg[11]/D            4.604         
-i_dsp/sum2_reg[17]/C           dac_dat_b_reg[13]/D            4.705         
-dac_dat_b_reg[4]/C             oddr_dac_dat[4]/D1             5.656         
-dac_dat_b_reg[9]/C             oddr_dac_dat[9]/D1             5.793         
-dac_dat_b_reg[13]/C            oddr_dac_dat[13]/D1            5.807         
-dac_dat_b_reg[12]/C            oddr_dac_dat[12]/D1            5.870         
-dac_rst_reg/C                  oddr_dac_rst/D1                5.884         
-dac_dat_b_reg[6]/C             oddr_dac_dat[6]/D1             5.893         
-dac_dat_b_reg[8]/C             oddr_dac_dat[8]/D1             5.913         
-dac_dat_b_reg[0]/C             oddr_dac_dat[0]/D1             5.979         
-dac_dat_b_reg[3]/C             oddr_dac_dat[3]/D1             5.983         
-dac_dat_b_reg[2]/C             oddr_dac_dat[2]/D1             5.989         
-dac_dat_b_reg[7]/C             oddr_dac_dat[7]/D1             6.034         
-dac_dat_b_reg[1]/C             oddr_dac_dat[1]/D1             6.043         
-dac_dat_b_reg[5]/C             oddr_dac_dat[5]/D1             6.045         
-dac_dat_b_reg[11]/C            oddr_dac_dat[11]/D1            6.057         
-dac_dat_b_reg[10]/C            oddr_dac_dat[10]/D1            6.057         
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[10]/CE
+                                                              0.272         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[12]/CE
+                                                              0.272         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[13]/CE
+                                                              0.272         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[1]/CE
+                                                              0.272         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[2]/CE
+                                                              0.272         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[11].GEN_REG_STATUS.ip_irpt_status_reg_reg[11]/D
+                                                              0.274         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/D
+                                                              0.276         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[8].ce_out_i_reg[8]/D
+                                                              0.277         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[20].ce_out_i_reg[20]/D
+                                                              0.279         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[17].ce_out_i_reg[17]/D
+                                                              0.282         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[15].ce_out_i_reg[15]/D
+                                                              0.285         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[10].ce_out_i_reg[10]/D
+                                                              0.293         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[13].GEN_REG_STATUS.ip_irpt_status_reg_reg[13]/D
+                                                              0.296         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_valid_i_reg/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_second_len_r_reg[3]/D
+                                                              0.306         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[3]/D
+                                                              0.313         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]/D
+                                                              0.316         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[0].GEN_REG_STATUS.ip_irpt_status_reg_reg[0]/D
+                                                              0.318         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[14].GEN_REG_STATUS.ip_irpt_status_reg_reg[14]/D
+                                                              0.322         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]/D
+                                                              0.332         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/I_DECODER/GEN_BKEND_CE_REGISTERS[13].ce_out_i_reg[13]/D
+                                                              0.339         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[1]/CE
+                                                              0.346         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/CE
+                                                              0.346         
+i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[2]/C
+                               i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/cnt_read_reg[4]/CE
+                                                              0.346         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[15]/CE
+                                                              0.348         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[16]/CE
+                                                              0.348         
+i_ps/system_i/system_i/processing_system7/inst/PS7_i/MAXIGP1ACLK
+                               i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/ip_irpt_enable_reg_reg[7]/CE
+                                                              0.348         
+i_ams/dac_b_o_reg[14]/C        pwm[1]/b_reg[14]/D             0.392         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[0]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[1]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[2]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[3]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[4]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[5]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[6]/CE             0.414         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/v_reg[7]/CE             0.414         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[10]/CE            0.433         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[7]/CE             0.433         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[8]/CE             0.433         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[9]/CE             0.433         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[14]/CE            0.440         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[0]/CE             0.446         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[0]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[1]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[2]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[3]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[4]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[5]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[6]/CE             0.450         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/v_reg[7]/CE             0.450         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[4]/CE             0.487         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[5]/CE             0.487         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[6]/CE             0.487         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[11]/CE            0.493         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[15]/CE            0.493         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[1]/CE             0.493         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[2]/CE             0.493         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[5]/CE             0.493         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[10]/CE            0.529         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[13]/CE            0.529         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[8]/CE             0.529         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[9]/CE             0.529         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[5]/CE             0.559         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[6]/CE             0.559         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[7]/CE             0.559         
+dac_rst_reg/C                  oddr_dac_dat[10]/R             0.568         
+dac_rst_reg/C                  oddr_dac_dat[4]/R              0.571         
+i_ams/dac_b_o_reg[16]/C        pwm[1]/v_reg[0]/D              0.584         
+dac_rst_reg/C                  oddr_dac_dat[13]/R             0.593         
+dac_rst_reg/C                  oddr_dac_dat[12]/R             0.595         
+dac_rst_reg/C                  oddr_dac_dat[0]/R              0.597         
+pwm_rstn_reg/C                 pwm[0]/pwm_o_reg/R             0.598         
+dac_rst_reg/C                  oddr_dac_dat[3]/R              0.601         
+dac_rst_reg/C                  oddr_dac_dat[2]/R              0.602         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[2]/CE             0.604         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[6]/CE             0.604         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[7]/CE             0.604         
+i_ams/dac_d_o_reg[3]/C         pwm[3]/b_reg[3]/D              0.611         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[0]/CE             0.612         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[1]/CE             0.612         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[3]/CE             0.612         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[4]/CE             0.612         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/v_reg[5]/CE             0.612         
+dac_rst_reg/C                  oddr_dac_dat[5]/R              0.617         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[12]/CE            0.625         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[13]/CE            0.625         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[11]/CE            0.626         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[12]/CE            0.626         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[4]/CE             0.626         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[5]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[1]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[2]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[3]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[4]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[5]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[6]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/v_reg[7]/CE             0.626         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[0]/CE             0.667         
+pwm[2]/vcnt_reg[4]/C           pwm[2]/b_reg[3]/CE             0.667         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[1]/CE             0.671         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[2]/CE             0.671         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[3]/CE             0.671         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[4]/CE             0.671         
+dac_rst_reg/C                  oddr_dac_dat[1]/R              0.690         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[7]/CE             0.692         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[8]/CE             0.692         
+pwm[3]/vcnt_reg[1]/C           pwm[3]/b_reg[9]/CE             0.692         
+dac_rst_reg/C                  oddr_dac_dat[11]/R             0.706         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[0]/CE             0.723         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[11]/CE            0.723         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[12]/CE            0.723         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/b_reg[13]/CE            0.723         
+i_ams/dac_a_o_reg[14]/C        pwm[0]/b_reg[14]/D             0.730         
+pwm_rstn_reg/C                 pwm[1]/pwm_o_reg/R             0.736         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[14]/CE            0.755         
+pwm[0]/vcnt_reg[1]/C           pwm[0]/b_reg[6]/CE             0.755         
+pwm[1]/vcnt_reg[2]/C           pwm[1]/vcnt_reg[5]/CE          0.758         
+i_ams/dac_b_o_reg[9]/C         pwm[1]/b_reg[9]/D              0.760         
+i_ams/dac_b_o_reg[5]/C         pwm[1]/b_reg[5]/D              0.771         
+pwm[2]/v_reg[2]/C              pwm[2]/v_r_reg[7]/D            0.777         
+dac_rst_reg/C                  oddr_dac_dat[7]/R              0.964         
+dac_rst_reg/C                  oddr_dac_dat[6]/R              1.002         
+dac_rst_reg/C                  oddr_dac_dat[9]/R              1.064         
+dac_rst_reg/C                  oddr_dac_dat[8]/R              1.105         
+dac_dat_a_reg[12]/C            oddr_dac_dat[12]/D2            1.382         
+dac_dat_a_reg[1]/C             oddr_dac_dat[1]/D2             1.382         
+dac_rst_reg/C                  oddr_dac_sel/R                 1.494         
+dac_dat_a_reg[10]/C            oddr_dac_dat[10]/D2            1.593         
+dac_dat_a_reg[7]/C             oddr_dac_dat[7]/D2             1.606         
+dac_dat_a_reg[5]/C             oddr_dac_dat[5]/D2             1.634         
+dac_dat_a_reg[13]/C            oddr_dac_dat[13]/D2            1.661         
+dac_dat_a_reg[3]/C             oddr_dac_dat[3]/D2             1.759         
+dac_dat_a_reg[6]/C             oddr_dac_dat[6]/D2             1.800         
+dac_dat_a_reg[9]/C             oddr_dac_dat[9]/D2             1.830         
+dac_rst_reg/C                  oddr_dac_rst/D2                1.853         
+dac_dat_a_reg[0]/C             oddr_dac_dat[0]/D2             1.874         
+dac_dat_a_reg[8]/C             oddr_dac_dat[8]/D2             1.915         
+dac_dat_a_reg[11]/C            oddr_dac_dat[11]/D2            1.994         
+dac_dat_a_reg[2]/C             oddr_dac_dat[2]/D2             2.051         
+dac_dat_a_reg[4]/C             oddr_dac_dat[4]/D2             2.129         
+i_dsp/sum2_reg[14]/C           dac_dat_b_reg[12]/D            2.743         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[2]/D             2.931         
+i_dsp/sum2_reg[14]/C           dac_dat_b_reg[9]/D             2.993         
+i_dsp/sum2_reg[13]/C           dac_dat_b_reg[1]/D             3.103         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[4]/D             3.179         
+i_dsp/sum2_reg[14]/C           dac_dat_b_reg[5]/D             3.286         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[3]/D             3.350         
+i_dsp/sum1_reg[16]/C           dac_dat_a_reg[1]/D             3.478         
+i_dsp/sum1_reg[16]/C           dac_dat_a_reg[11]/D            3.506         
+i_dsp/sum1_reg[5]/C            dac_dat_a_reg[5]/D             3.525         
+i_dsp/sum2_reg[3]/C            dac_dat_b_reg[3]/D             3.542         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[12]/D            3.550         
+i_dsp/sum2_reg[13]/C           dac_dat_b_reg[4]/D             3.638         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[0]/D             3.678         
+i_dsp/sum1_reg[13]/C           dac_dat_a_reg[8]/D             3.710         
+i_dsp/sum2_reg[16]/C           dac_dat_b_reg[8]/D             3.789         
+i_dsp/sum2_reg[13]/C           dac_dat_b_reg[6]/D             3.856         
+i_dsp/sum2_reg[14]/C           dac_dat_b_reg[0]/D             3.860         
+i_dsp/sum1_reg[17]/C           dac_dat_a_reg[13]/D            3.960         
+i_dsp/sum2_reg[7]/C            dac_dat_b_reg[7]/D             4.069         
+i_dsp/sum2_reg[2]/C            dac_dat_b_reg[2]/D             4.083         
+i_dsp/sum2_reg[16]/C           dac_dat_b_reg[10]/D            4.173         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[6]/D             4.207         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[9]/D             4.216         
+i_dsp/sum1_reg[10]/C           dac_dat_a_reg[10]/D            4.495         
+i_dsp/sum2_reg[14]/C           dac_dat_b_reg[11]/D            4.509         
+i_dsp/sum1_reg[14]/C           dac_dat_a_reg[7]/D             4.610         
+i_dsp/sum2_reg[17]/C           dac_dat_b_reg[13]/D            4.655         
+dac_dat_b_reg[13]/C            oddr_dac_dat[13]/D1            5.040         
+dac_dat_b_reg[3]/C             oddr_dac_dat[3]/D1             5.291         
+dac_dat_b_reg[5]/C             oddr_dac_dat[5]/D1             5.501         
+dac_dat_b_reg[7]/C             oddr_dac_dat[7]/D1             5.596         
+dac_dat_b_reg[11]/C            oddr_dac_dat[11]/D1            5.600         
+dac_dat_b_reg[10]/C            oddr_dac_dat[10]/D1            5.604         
+dac_dat_b_reg[2]/C             oddr_dac_dat[2]/D1             5.611         
+dac_dat_b_reg[6]/C             oddr_dac_dat[6]/D1             5.612         
+dac_dat_b_reg[4]/C             oddr_dac_dat[4]/D1             5.615         
+dac_rst_reg/C                  oddr_dac_rst/D1                5.664         
+dac_dat_b_reg[8]/C             oddr_dac_dat[8]/D1             5.765         
+dac_dat_b_reg[9]/C             oddr_dac_dat[9]/D1             5.768         
+dac_dat_b_reg[12]/C            oddr_dac_dat[12]/D1            5.857         
+dac_dat_b_reg[1]/C             oddr_dac_dat[1]/D1             5.871         
+dac_dat_b_reg[0]/C             oddr_dac_dat[0]/D1             5.873         
 
 
 

--- a/pyrpl/fpga/out/post_route_timing_summary.rpt
+++ b/pyrpl/fpga/out/post_route_timing_summary.rpt
@@ -1,13 +1,14 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-------------------------------------------------------------------------------------
-| Tool Version : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date         : Fri Mar 17 14:13:55 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:33:45 2025
 | Host         : fontana running 64-bit major release  (build 9200)
 | Command      : report_timing_summary -file out/post_route_timing_summary.rpt
 | Design       : red_pitaya_top
 | Device       : 7z010-clg400
-| Speed File   : -1  PRODUCTION 1.11 2014-09-11
-------------------------------------------------------------------------------------
+| Speed File   : -1  PRODUCTION 1.12 2019-11-22
+| Design State : Routed
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Timing Summary Report
 
@@ -23,7 +24,10 @@ Timing Summary Report
   Enable Preset / Clear Arcs                 :  No
   Disable Flight Delays                      :  No
   Ignore I/O Paths                           :  No
-  Timing Early Launch at Borrowing Latches   :  false
+  Timing Early Launch at Borrowing Latches   :  No
+  Borrow Time for Max Delay Exceptions       :  Yes
+  Merge Timing Exceptions                    :  Yes
+  Inter-SLR Compensation                     :  Conservative
 
   Corner  Analyze    Analyze    
   Name    Max Paths  Min Paths  
@@ -32,55 +36,63 @@ Timing Summary Report
   Fast    Yes        Yes        
 
 
+------------------------------------------------------------------------------------------------
+| Report Methodology
+| ------------------
+------------------------------------------------------------------------------------------------
+
+No report available as report_methodology has not been run prior. Run report_methodology on the current design for the summary of methodology violations.
+
+
 
 check_timing report
 
 Table of Contents
 -----------------
-1. checking no_clock
-2. checking constant_clock
-3. checking pulse_width_clock
-4. checking unconstrained_internal_endpoints
-5. checking no_input_delay
-6. checking no_output_delay
-7. checking multiple_clock
-8. checking generated_clocks
-9. checking loops
-10. checking partial_input_delay
-11. checking partial_output_delay
-12. checking latch_loops
+1. checking no_clock (1)
+2. checking constant_clock (0)
+3. checking pulse_width_clock (0)
+4. checking unconstrained_internal_endpoints (2)
+5. checking no_input_delay (16)
+6. checking no_output_delay (46)
+7. checking multiple_clock (0)
+8. checking generated_clocks (0)
+9. checking loops (0)
+10. checking partial_input_delay (0)
+11. checking partial_output_delay (0)
+12. checking latch_loops (0)
 
-1. checking no_clock
---------------------
- There is 1 register/latch pin with no clock driven by root clock pin: i_hk/dna_clk_reg/C (HIGH)
+1. checking no_clock (1)
+------------------------
+ There is 1 register/latch pin with no clock driven by root clock pin: i_hk/dna_clk_reg/Q (HIGH)
 
 
-2. checking constant_clock
---------------------------
+2. checking constant_clock (0)
+------------------------------
  There are 0 register/latch pins with constant_clock.
 
 
-3. checking pulse_width_clock
------------------------------
+3. checking pulse_width_clock (0)
+---------------------------------
  There are 0 register/latch pins which need pulse_width check
 
 
-4. checking unconstrained_internal_endpoints
---------------------------------------------
+4. checking unconstrained_internal_endpoints (2)
+------------------------------------------------
  There are 2 pins that are not constrained for maximum delay. (HIGH)
 
  There are 0 pins that are not constrained for maximum delay due to constant clock.
 
 
-5. checking no_input_delay
---------------------------
+5. checking no_input_delay (16)
+-------------------------------
  There are 16 input ports with no input delay specified. (HIGH)
 
  There are 0 input ports with no input delay but user has a false path constraint.
 
 
-6. checking no_output_delay
----------------------------
+6. checking no_output_delay (46)
+--------------------------------
  There are 46 ports with no output delay specified. (HIGH)
 
  There are 0 ports with no output delay but user has a false path constraint
@@ -88,33 +100,33 @@ Table of Contents
  There are 0 ports with no output delay but with a timing clock defined on it or propagating through it
 
 
-7. checking multiple_clock
---------------------------
+7. checking multiple_clock (0)
+------------------------------
  There are 0 register/latch pins with multiple clocks.
 
 
-8. checking generated_clocks
-----------------------------
+8. checking generated_clocks (0)
+--------------------------------
  There are 0 generated clocks that are not connected to a clock source.
 
 
-9. checking loops
------------------
+9. checking loops (0)
+---------------------
  There are 0 combinational loops in the design.
 
 
-10. checking partial_input_delay
---------------------------------
+10. checking partial_input_delay (0)
+------------------------------------
  There are 0 input ports with partial input delay specified.
 
 
-11. checking partial_output_delay
----------------------------------
+11. checking partial_output_delay (0)
+-------------------------------------
  There are 0 ports with partial output delay specified.
 
 
-12. checking latch_loops
-------------------------
+12. checking latch_loops (0)
+----------------------------
  There are 0 combinational latch loops in the design through latch input
 
 
@@ -126,7 +138,7 @@ Table of Contents
 
     WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints     WPWS(ns)     TPWS(ns)  TPWS Failing Endpoints  TPWS Total Endpoints  
     -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
-     -5.896   -21698.340                  13232                36512       -2.163      -58.853                     28                36512        1.000        0.000                       0                 14501  
+     -4.965   -12868.471                  11287                36492       -2.162      -58.825                     28                36492        1.000        0.000                       0                 14396  
 
 
 Timing constraints are not met.
@@ -162,12 +174,12 @@ Clock                 WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total End
 -----                 -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
 adc_clk                                                                                                                                                             2.000        0.000                       0                     1  
   clk_fb                                                                                                                                                            6.751        0.000                       0                     2  
-  pll_adc_clk          -5.896   -21513.055                  12901                34128        0.054        0.000                      0                34128        2.750        0.000                       0                 13377  
-  pll_dac_clk_1x        0.538        0.000                      0                   45        0.252        0.000                      0                   45        3.500        0.000                       0                    47  
+  pll_adc_clk          -4.965   -12866.211                  11273                34256        0.050        0.000                      0                34256        3.500        0.000                       0                 13372  
+  pll_dac_clk_1x        0.568        0.000                      0                   45        0.106        0.000                      0                   45        3.500        0.000                       0                    47  
   pll_dac_clk_2p                                                                                                                                                    1.845        0.000                       0                     3  
   pll_dac_clk_2x                                                                                                                                                    1.845        0.000                       0                     3  
-  pll_pwm_clk          -0.724       -4.491                     22                  412        0.071        0.000                      0                  412        1.500        0.000                       0                   217  
-clk_fpga_3             -2.193     -180.793                    309                 1839        0.122        0.000                      0                 1839        1.000        0.000                       0                   851  
+  pll_pwm_clk          -0.406       -1.305                      4                  440        0.143        0.000                      0                  440        1.500        0.000                       0                   217  
+clk_fpga_3             -0.216       -0.953                     10                 1663        0.081        0.000                      0                 1663        1.000        0.000                       0                   751  
 
 
 ------------------------------------------------------------------------------------------------
@@ -177,9 +189,9 @@ clk_fpga_3             -2.193     -180.793                    309               
 
 From Clock      To Clock            WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints  
 ----------      --------            -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------  
-adc_clk         pll_adc_clk           5.940        0.000                      0                   28       -2.163      -58.853                     28                   28  
-pll_adc_clk     pll_dac_clk_1x        3.061        0.000                      0                   28        0.275        0.000                      0                   28  
-pll_adc_clk     pll_pwm_clk           0.272        0.000                      0                   94        0.188        0.000                      0                   94  
+adc_clk         pll_adc_clk           5.939        0.000                      0                   28       -2.162      -58.825                     28                   28  
+pll_adc_clk     pll_dac_clk_1x        2.743        0.000                      0                   28        0.198        0.000                      0                   28  
+pll_adc_clk     pll_pwm_clk           0.392        0.000                      0                   94        0.128        0.000                      0                   94  
 
 
 ------------------------------------------------------------------------------------------------
@@ -217,7 +229,7 @@ Sources:            { adc_clk_p_i }
 Check Type        Corner  Lib Pin           Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
 Min Period        n/a     PLLE2_ADV/CLKIN1  n/a            1.249         8.000       6.751      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
 Max Period        n/a     PLLE2_ADV/CLKIN1  n/a            52.633        8.000       44.633     PLLE2_ADV_X0Y0  pll/pll/CLKIN1
-Low Pulse Width   Fast    PLLE2_ADV/CLKIN1  n/a            2.000         4.000       2.000      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
+Low Pulse Width   Slow    PLLE2_ADV/CLKIN1  n/a            2.000         4.000       2.000      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
 High Pulse Width  Slow    PLLE2_ADV/CLKIN1  n/a            2.000         4.000       2.000      PLLE2_ADV_X0Y0  pll/pll/CLKIN1
 
 
@@ -249,27 +261,27 @@ Max Period  n/a     PLLE2_ADV/CLKFBIN   n/a            52.633        8.000      
 From Clock:  pll_adc_clk
   To Clock:  pll_adc_clk
 
-Setup :        12901  Failing Endpoints,  Worst Slack       -5.896ns,  Total Violation   -21513.055ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.054ns,  Total Violation        0.000ns
-PW    :            0  Failing Endpoints,  Worst Slack        2.750ns,  Total Violation        0.000ns
+Setup :        11273  Failing Endpoints,  Worst Slack       -4.965ns,  Total Violation   -12866.211ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.050ns,  Total Violation        0.000ns
+PW    :            0  Failing Endpoints,  Worst Slack        3.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -5.896ns  (required time - arrival time)
-  Source:                 i_dsp/genblk4[4].iir/x0b_reg[15]/C
+Slack (VIOLATED) :        -4.965ns  (required time - arrival time)
+  Source:                 i_dsp/genblk4[4].iir/x0b_reg[16]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            i_dsp/genblk4[4].iir/overflow_reg[3]/D
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_adc_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            8.000ns  (pll_adc_clk rise@8.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        13.755ns  (logic 9.374ns (68.148%)  route 4.381ns (31.852%))
-  Logic Levels:           17  (CARRY4=13 DSP48E1=2 LUT2=1 LUT4=1)
-  Clock Path Skew:        -0.104ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.453ns = ( 13.453 - 8.000 ) 
-    Source Clock Delay      (SCD):    5.914ns
+  Data Path Delay:        12.762ns  (logic 9.429ns (73.885%)  route 3.333ns (26.115%))
+  Logic Levels:           19  (CARRY4=14 DSP48E1=2 LUT1=1 LUT2=1 LUT5=1)
+  Clock Path Skew:        -0.164ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.385ns = ( 13.385 - 8.000 ) 
+    Source Clock Delay      (SCD):    5.906ns
     Clock Pessimism Removal (CPR):    0.357ns
   Clock Uncertainty:      0.069ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -288,61 +300,66 @@ Slack (VIOLATED) :        -5.896ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       1.681     5.914    i_dsp/genblk4[4].iir/clk_i
-    SLICE_X12Y6          FDRE                                         r  i_dsp/genblk4[4].iir/x0b_reg[15]/C
+                         net (fo=13385, routed)       1.673     5.906    i_dsp/genblk4[4].iir/clk_i
+    SLICE_X33Y8          FDRE                                         r  i_dsp/genblk4[4].iir/x0b_reg[16]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X12Y6          FDRE (Prop_fdre_C_Q)         0.518     6.432 r  i_dsp/genblk4[4].iir/x0b_reg[15]/Q
-                         net (fo=1, routed)           1.262     7.694    i_dsp/genblk4[4].iir/p_bx0_module/factor1_i[15]
-    DSP48_X1Y0           DSP48E1 (Prop_dsp48e1_A[15]_PCOUT[47])
-                                                      4.036    11.730 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__1/PCOUT[47]
-                         net (fo=1, routed)           0.002    11.732    i_dsp/genblk4[4].iir/p_bx0_module/product0__1_n_106
-    DSP48_X1Y1           DSP48E1 (Prop_dsp48e1_PCIN[47]_P[0])
-                                                      1.518    13.250 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[0]
-                         net (fo=2, routed)           1.032    14.282    i_dsp/genblk4[4].iir/p_bx0_module/product0__2_n_105
-    SLICE_X32Y6          CARRY4 (Prop_carry4_DI[1]_CO[3])
-                                                      0.520    14.802 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_17/CO[3]
-                         net (fo=1, routed)           0.000    14.802    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_17_n_0
-    SLICE_X32Y7          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    14.919 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_12/CO[3]
-                         net (fo=1, routed)           0.000    14.919    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_12_n_0
-    SLICE_X32Y8          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.036 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_7/CO[3]
-                         net (fo=1, routed)           0.000    15.036    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_7_n_0
-    SLICE_X32Y9          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.153 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2/CO[3]
-                         net (fo=1, routed)           0.000    15.153    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2_n_0
-    SLICE_X32Y10         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.270 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_6/CO[3]
-                         net (fo=1, routed)           0.000    15.270    i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_6_n_0
-    SLICE_X32Y11         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.387 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_6/CO[3]
-                         net (fo=1, routed)           0.000    15.387    i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_6_n_0
-    SLICE_X32Y12         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.504 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_6/CO[3]
-                         net (fo=1, routed)           0.000    15.504    i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_6_n_0
-    SLICE_X32Y13         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.621 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_6/CO[3]
-                         net (fo=1, routed)           0.000    15.621    i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_6_n_0
-    SLICE_X32Y14         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.738 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_6/CO[3]
-                         net (fo=1, routed)           0.000    15.738    i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_6_n_0
-    SLICE_X32Y15         CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.117    15.855 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_6/CO[3]
-                         net (fo=1, routed)           0.000    15.855    i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_6_n_0
-    SLICE_X32Y16         CARRY4 (Prop_carry4_CI_O[0])
-                                                      0.219    16.074 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_6/O[0]
-                         net (fo=1, routed)           0.814    16.889    i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_6_n_7
-    SLICE_X36Y16         CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.845    17.734 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_1/CO[3]
-                         net (fo=1, routed)           0.000    17.734    i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_1_n_0
-    SLICE_X36Y17         CARRY4 (Prop_carry4_CI_O[2])
-                                                      0.239    17.973 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1/O[2]
-                         net (fo=32, routed)          0.966    18.939    i_dsp/genblk4[4].iir/p_bx0_module/p_0_in[1]
-    SLICE_X36Y19         LUT4 (Prop_lut4_I0_O)        0.302    19.241 r  i_dsp/genblk4[4].iir/p_bx0_module/overflow_INST_0/O
-                         net (fo=1, routed)           0.305    19.546    i_dsp/genblk4[4].iir/overflow_i[3]
-    SLICE_X36Y21         LUT2 (Prop_lut2_I0_O)        0.124    19.670 r  i_dsp/genblk4[4].iir/overflow[3]_i_1/O
-                         net (fo=1, routed)           0.000    19.670    i_dsp/genblk4[4].iir/overflow[3]_i_1_n_0
-    SLICE_X36Y21         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/D
+    SLICE_X33Y8          FDRE (Prop_fdre_C_Q)         0.456     6.362 r  i_dsp/genblk4[4].iir/x0b_reg[16]/Q
+                         net (fo=1, routed)           0.583     6.945    i_dsp/genblk4[4].iir/p_bx0_module/factor1_i[16]
+    DSP48_X1Y2           DSP48E1 (Prop_dsp48e1_A[16]_PCOUT[47])
+                                                      4.036    10.981 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__1/PCOUT[47]
+                         net (fo=1, routed)           0.002    10.983    i_dsp/genblk4[4].iir/p_bx0_module/product0__1_n_106
+    DSP48_X1Y3           DSP48E1 (Prop_dsp48e1_PCIN[47]_P[0])
+                                                      1.518    12.501 r  i_dsp/genblk4[4].iir/p_bx0_module/product0__2/P[0]
+                         net (fo=2, routed)           0.964    13.466    i_dsp/genblk4[4].iir/p_bx0_module/product0__2_n_105
+    SLICE_X31Y1          LUT2 (Prop_lut2_I0_O)        0.124    13.590 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_16/O
+                         net (fo=1, routed)           0.000    13.590    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_16_n_0
+    SLICE_X31Y1          CARRY4 (Prop_carry4_S[1]_CO[3])
+                                                      0.550    14.140 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_9/CO[3]
+                         net (fo=1, routed)           0.000    14.140    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_9_n_0
+    SLICE_X31Y2          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    14.254 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_4/CO[3]
+                         net (fo=1, routed)           0.000    14.254    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_4_n_0
+    SLICE_X31Y3          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    14.368 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_3/CO[3]
+                         net (fo=1, routed)           0.000    14.368    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_3_n_0
+    SLICE_X31Y4          CARRY4 (Prop_carry4_CI_O[0])
+                                                      0.222    14.590 f  i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_2/O[0]
+                         net (fo=2, routed)           0.577    15.166    i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_2_n_7
+    SLICE_X29Y4          LUT1 (Prop_lut1_I0_O)        0.299    15.465 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2/O
+                         net (fo=1, routed)           0.000    15.465    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_2_n_0
+    SLICE_X29Y4          CARRY4 (Prop_carry4_S[1]_CO[3])
+                                                      0.550    16.015 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.015    i_dsp/genblk4[4].iir/p_bx0_module/product_o[1]_INST_0_i_1_n_0
+    SLICE_X29Y5          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.129 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.129    i_dsp/genblk4[4].iir/p_bx0_module/product_o[5]_INST_0_i_1_n_0
+    SLICE_X29Y6          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.243 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.243    i_dsp/genblk4[4].iir/p_bx0_module/product_o[9]_INST_0_i_1_n_0
+    SLICE_X29Y7          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.357 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.357    i_dsp/genblk4[4].iir/p_bx0_module/product_o[13]_INST_0_i_1_n_0
+    SLICE_X29Y8          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.471 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.471    i_dsp/genblk4[4].iir/p_bx0_module/product_o[17]_INST_0_i_1_n_0
+    SLICE_X29Y9          CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.585 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.585    i_dsp/genblk4[4].iir/p_bx0_module/product_o[21]_INST_0_i_1_n_0
+    SLICE_X29Y10         CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.699 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.699    i_dsp/genblk4[4].iir/p_bx0_module/product_o[25]_INST_0_i_1_n_0
+    SLICE_X29Y11         CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.813 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.813    i_dsp/genblk4[4].iir/p_bx0_module/product_o[29]_INST_0_i_1_n_0
+    SLICE_X29Y12         CARRY4 (Prop_carry4_CI_CO[3])
+                                                      0.114    16.927 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1/CO[3]
+                         net (fo=1, routed)           0.000    16.927    i_dsp/genblk4[4].iir/p_bx0_module/product_o[30]_INST_0_i_1_n_0
+    SLICE_X29Y13         CARRY4 (Prop_carry4_CI_O[0])
+                                                      0.235    17.162 r  i_dsp/genblk4[4].iir/p_bx0_module/product_o[31]_INST_0_i_1/O[0]
+                         net (fo=33, routed)          1.206    18.369    i_dsp/genblk4[4].iir/p_bx0_full[31]
+    SLICE_X18Y14         LUT5 (Prop_lut5_I0_O)        0.299    18.668 r  i_dsp/genblk4[4].iir/overflow[3]_i_1_LOPT_REMAP/O
+                         net (fo=1, routed)           0.000    18.668    i_dsp/genblk4[4].iir/overflow[3]_i_1_n_0
+    SLICE_X18Y14         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_adc_clk rise edge)
@@ -355,16 +372,16 @@ Slack (VIOLATED) :        -5.896ns  (required time - arrival time)
                                                       0.084    10.205 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           1.594    11.799    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.091    11.890 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       1.563    13.453    i_dsp/genblk4[4].iir/clk_i
-    SLICE_X36Y21         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/C
-                         clock pessimism              0.357    13.811    
-                         clock uncertainty           -0.069    13.742    
-    SLICE_X36Y21         FDRE (Setup_fdre_C_D)        0.032    13.774    i_dsp/genblk4[4].iir/overflow_reg[3]
+                         net (fo=13385, routed)       1.495    13.385    i_dsp/genblk4[4].iir/clk_i
+    SLICE_X18Y14         FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[3]/C
+                         clock pessimism              0.357    13.743    
+                         clock uncertainty           -0.069    13.674    
+    SLICE_X18Y14         FDRE (Setup_fdre_C_D)        0.029    13.703    i_dsp/genblk4[4].iir/overflow_reg[3]
   -------------------------------------------------------------------
-                         required time                         13.774    
-                         arrival time                         -19.670    
+                         required time                         13.703    
+                         arrival time                         -18.668    
   -------------------------------------------------------------------
-                         slack                                 -5.896    
+                         slack                                 -4.965    
 
 
 
@@ -372,20 +389,20 @@ Slack (VIOLATED) :        -5.896ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.054ns  (arrival time - required time)
-  Source:                 i_dsp/genblk4[4].iir/x0_reg[18]/C
+Slack (MET) :             0.050ns  (arrival time - required time)
+  Source:                 i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[12]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            i_dsp/genblk4[4].iir/x0_i_reg[13][18]/D
+  Destination:            i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[16]/D
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_adc_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_adc_clk rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.365ns  (logic 0.141ns (38.635%)  route 0.224ns (61.365%))
-  Logic Levels:           0  
-  Clock Path Skew:        0.259ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.360ns
-    Source Clock Delay      (SCD):    1.970ns
-    Clock Pessimism Removal (CPR):    0.130ns
+  Data Path Delay:        0.454ns  (logic 0.386ns (85.079%)  route 0.068ns (14.921%))
+  Logic Levels:           2  (CARRY4=2)
+  Clock Path Skew:        0.269ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.371ns
+    Source Clock Delay      (SCD):    1.976ns
+    Clock Pessimism Removal (CPR):    0.125ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -399,12 +416,18 @@ Slack (MET) :             0.054ns  (arrival time - required time)
                                                       0.051     0.893 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           0.497     1.390    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     1.416 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       0.555     1.970    i_dsp/genblk4[4].iir/clk_i
-    SLICE_X21Y33         FDRE                                         r  i_dsp/genblk4[4].iir/x0_reg[18]/C
+                         net (fo=13385, routed)       0.561     1.976    i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/clk_i
+    SLICE_X20Y49         FDRE                                         r  i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[12]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X21Y33         FDRE (Prop_fdre_C_Q)         0.141     2.111 r  i_dsp/genblk4[4].iir/x0_reg[18]/Q
-                         net (fo=15, routed)          0.224     2.335    i_dsp/genblk4[4].iir/x0[18]
-    SLICE_X24Y31         FDRE                                         r  i_dsp/genblk4[4].iir/x0_i_reg[13][18]/D
+    SLICE_X20Y49         FDRE (Prop_fdre_C_Q)         0.164     2.140 r  i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[12]/Q
+                         net (fo=2, routed)           0.067     2.207    i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg_n_0_[12]
+    SLICE_X20Y49         CARRY4 (Prop_carry4_DI[0]_CO[3])
+                                                      0.169     2.376 r  i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[12]_i_1/CO[3]
+                         net (fo=1, routed)           0.001     2.377    i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[12]_i_1_n_0
+    SLICE_X20Y50         CARRY4 (Prop_carry4_CI_O[0])
+                                                      0.053     2.430 r  i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[16]_i_1/O[0]
+                         net (fo=1, routed)           0.000     2.430    i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[16]_i_1_n_7
+    SLICE_X20Y50         FDRE                                         r  i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[16]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_adc_clk rise edge)
@@ -417,15 +440,15 @@ Slack (MET) :             0.054ns  (arrival time - required time)
                                                       0.054     0.968 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           0.544     1.512    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.029     1.541 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       0.819     2.360    i_dsp/genblk4[4].iir/clk_i
-    SLICE_X24Y31         FDRE                                         r  i_dsp/genblk4[4].iir/x0_i_reg[13][18]/C
-                         clock pessimism             -0.130     2.230    
-    SLICE_X24Y31         FDRE (Hold_fdre_C_D)         0.052     2.282    i_dsp/genblk4[4].iir/x0_i_reg[13][18]
+                         net (fo=13385, routed)       0.830     2.371    i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/clk_i
+    SLICE_X20Y50         FDRE                                         r  i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[16]/C
+                         clock pessimism             -0.125     2.246    
+    SLICE_X20Y50         FDRE (Hold_fdre_C_D)         0.134     2.380    i_dsp/genblk2[1].i_pid/pidfilter/genblk2[0].lpf/y_reg[16]
   -------------------------------------------------------------------
-                         required time                         -2.282    
-                         arrival time                           2.335    
+                         required time                         -2.380    
+                         arrival time                           2.430    
   -------------------------------------------------------------------
-                         slack                                  0.054    
+                         slack                                  0.050    
 
 
 
@@ -439,10 +462,10 @@ Period(ns):         8.000
 Sources:            { pll/pll/CLKOUT0 }
 
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
-Min Period        n/a     DSP48E1/CLK        n/a            3.884         8.000       4.116      DSP48_X1Y32     i_dsp/genblk2[0].i_pid/kp_mult0/CLK
+Min Period        n/a     DSP48E1/CLK        n/a            3.884         8.000       4.116      DSP48_X0Y28     i_dsp/genblk2[0].i_pid/ki_mult_reg/CLK
 Max Period        n/a     PLLE2_ADV/CLKOUT0  n/a            160.000       8.000       152.000    PLLE2_ADV_X0Y0  pll/pll/CLKOUT0
-Low Pulse Width   Slow    RAMD32/CLK         n/a            1.250         4.000       2.750      SLICE_X0Y4      i_ps/axi_master[0]/axi_awfifo_reg_0_15_30_35/RAMA/CLK
-High Pulse Width  Slow    RAMD32/CLK         n/a            1.250         4.000       2.750      SLICE_X0Y1      i_ps/axi_master[0]/axi_wfifo_reg_0_15_60_65/RAMA/CLK
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X42Y44    adc_rstn_reg/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X42Y44    adc_rstn_reg/C
 
 
 
@@ -450,27 +473,27 @@ High Pulse Width  Slow    RAMD32/CLK         n/a            1.250         4.000 
 From Clock:  pll_dac_clk_1x
   To Clock:  pll_dac_clk_1x
 
-Setup :            0  Failing Endpoints,  Worst Slack        0.538ns,  Total Violation        0.000ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.252ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        0.568ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.106ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        3.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.538ns  (required time - arrival time)
+Slack (MET) :             0.568ns  (required time - arrival time)
   Source:                 dac_rst_reg/C
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            oddr_dac_dat[13]/R
+  Destination:            oddr_dac_dat[10]/R
                             (falling edge-triggered cell ODDR clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_dac_clk_1x
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_dac_clk_1x fall@4.000ns - pll_dac_clk_1x rise@0.000ns)
-  Data Path Delay:        2.513ns  (logic 0.456ns (18.146%)  route 2.057ns (81.854%))
+  Data Path Delay:        2.472ns  (logic 0.456ns (18.450%)  route 2.016ns (81.550%))
   Logic Levels:           0  
-  Clock Path Skew:        -0.083ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.434ns = ( 9.434 - 4.000 ) 
-    Source Clock Delay      (SCD):    5.974ns
+  Clock Path Skew:        -0.094ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.425ns = ( 9.425 - 4.000 ) 
+    Source Clock Delay      (SCD):    5.976ns
     Clock Pessimism Removal (CPR):    0.457ns
   Clock Uncertainty:      0.069ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -489,12 +512,12 @@ Slack (MET) :             0.538ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT1
                          net (fo=1, routed)           1.754     4.132    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_dac_clk_1x/O
-                         net (fo=45, routed)          1.741     5.974    dac_clk_1x
-    SLICE_X43Y59         FDRE                                         r  dac_rst_reg/C
+                         net (fo=45, routed)          1.743     5.976    dac_clk_1x
+    SLICE_X43Y55         FDRE                                         r  dac_rst_reg/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X43Y59         FDRE (Prop_fdre_C_Q)         0.456     6.430 r  dac_rst_reg/Q
-                         net (fo=17, routed)          2.057     8.487    dac_rst
-    OLOGIC_X0Y92         ODDR                                         r  oddr_dac_dat[13]/R
+    SLICE_X43Y55         FDRE (Prop_fdre_C_Q)         0.456     6.432 r  dac_rst_reg/Q
+                         net (fo=17, routed)          2.016     8.448    dac_rst
+    OLOGIC_X0Y70         ODDR                                         r  oddr_dac_dat[10]/R
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_dac_clk_1x fall edge)
@@ -507,16 +530,16 @@ Slack (MET) :             0.538ns  (required time - arrival time)
                                                       0.084     6.205 f  pll/pll/CLKOUT1
                          net (fo=1, routed)           1.594     7.799    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.091     7.890 f  bufg_dac_clk_1x/O
-                         net (fo=45, routed)          1.544     9.434    dac_clk_1x
-    OLOGIC_X0Y92         ODDR                                         f  oddr_dac_dat[13]/C
-                         clock pessimism              0.457     9.892    
-                         clock uncertainty           -0.069     9.823    
-    OLOGIC_X0Y92         ODDR (Setup_oddr_C_R)       -0.798     9.025    oddr_dac_dat[13]
+                         net (fo=45, routed)          1.535     9.425    dac_clk_1x
+    OLOGIC_X0Y70         ODDR                                         f  oddr_dac_dat[10]/C
+                         clock pessimism              0.457     9.883    
+                         clock uncertainty           -0.069     9.814    
+    OLOGIC_X0Y70         ODDR (Setup_oddr_C_R)       -0.798     9.016    oddr_dac_dat[10]
   -------------------------------------------------------------------
-                         required time                          9.025    
-                         arrival time                          -8.487    
+                         required time                          9.016    
+                         arrival time                          -8.448    
   -------------------------------------------------------------------
-                         slack                                  0.538    
+                         slack                                  0.568    
 
 
 
@@ -524,7 +547,7 @@ Slack (MET) :             0.538ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.252ns  (arrival time - required time)
+Slack (MET) :             0.106ns  (arrival time - required time)
   Source:                 dac_rst_reg/C
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            oddr_dac_sel/R
@@ -532,11 +555,11 @@ Slack (MET) :             0.252ns  (arrival time - required time)
   Path Group:             pll_dac_clk_1x
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_dac_clk_1x rise@0.000ns - pll_dac_clk_1x rise@0.000ns)
-  Data Path Delay:        0.758ns  (logic 0.141ns (18.602%)  route 0.617ns (81.398%))
+  Data Path Delay:        0.611ns  (logic 0.141ns (23.073%)  route 0.470ns (76.927%))
   Logic Levels:           0  
-  Clock Path Skew:        0.030ns (DCD - SCD - CPR)
+  Clock Path Skew:        0.029ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    2.394ns
-    Source Clock Delay      (SCD):    2.004ns
+    Source Clock Delay      (SCD):    2.005ns
     Clock Pessimism Removal (CPR):    0.360ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
@@ -551,11 +574,11 @@ Slack (MET) :             0.252ns  (arrival time - required time)
                                                       0.051     0.893 r  pll/pll/CLKOUT1
                          net (fo=1, routed)           0.497     1.390    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.026     1.416 r  bufg_dac_clk_1x/O
-                         net (fo=45, routed)          0.589     2.004    dac_clk_1x
-    SLICE_X43Y59         FDRE                                         r  dac_rst_reg/C
+                         net (fo=45, routed)          0.590     2.005    dac_clk_1x
+    SLICE_X43Y55         FDRE                                         r  dac_rst_reg/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X43Y59         FDRE (Prop_fdre_C_Q)         0.141     2.145 r  dac_rst_reg/Q
-                         net (fo=17, routed)          0.617     2.762    dac_rst
+    SLICE_X43Y55         FDRE (Prop_fdre_C_Q)         0.141     2.146 r  dac_rst_reg/Q
+                         net (fo=17, routed)          0.470     2.616    dac_rst
     OLOGIC_X0Y57         ODDR                                         r  oddr_dac_sel/R
   -------------------------------------------------------------------    -------------------
 
@@ -575,9 +598,9 @@ Slack (MET) :             0.252ns  (arrival time - required time)
     OLOGIC_X0Y57         ODDR (Hold_oddr_C_R)         0.476     2.510    oddr_dac_sel
   -------------------------------------------------------------------
                          required time                         -2.510    
-                         arrival time                           2.762    
+                         arrival time                           2.616    
   -------------------------------------------------------------------
-                         slack                                  0.252    
+                         slack                                  0.106    
 
 
 
@@ -593,8 +616,8 @@ Sources:            { pll/pll/CLKOUT1 }
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
 Min Period        n/a     BUFG/I             n/a            2.155         8.000       5.845      BUFGCTRL_X0Y3   bufg_dac_clk_1x/I
 Max Period        n/a     PLLE2_ADV/CLKOUT1  n/a            160.000       8.000       152.000    PLLE2_ADV_X0Y0  pll/pll/CLKOUT1
-Low Pulse Width   Fast    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X41Y86    dac_dat_a_reg[0]/C
-High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X38Y65    dac_dat_a_reg[7]/C
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X41Y82    dac_dat_a_reg[0]/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500      SLICE_X41Y82    dac_dat_a_reg[0]/C
 
 
 
@@ -648,28 +671,28 @@ Max Period  n/a     PLLE2_ADV/CLKOUT2  n/a            160.000       4.000       
 From Clock:  pll_pwm_clk
   To Clock:  pll_pwm_clk
 
-Setup :           22  Failing Endpoints,  Worst Slack       -0.724ns,  Total Violation       -4.491ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.071ns,  Total Violation        0.000ns
+Setup :            4  Failing Endpoints,  Worst Slack       -0.406ns,  Total Violation       -1.305ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.143ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        1.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.724ns  (required time - arrival time)
-  Source:                 pwm[0]/vcnt_r_reg[0]/C
+Slack (VIOLATED) :        -0.406ns  (required time - arrival time)
+  Source:                 pwm[0]/v_r_reg[1]/C
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Destination:            pwm[0]/pwm_o_reg/D
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_pwm_clk rise@4.000ns - pll_pwm_clk rise@0.000ns)
-  Data Path Delay:        3.478ns  (logic 1.409ns (40.515%)  route 2.069ns (59.485%))
+  Data Path Delay:        3.180ns  (logic 1.518ns (47.731%)  route 1.662ns (52.269%))
   Logic Levels:           3  (CARRY4=2 LUT4=1)
-  Clock Path Skew:        -0.106ns (DCD - SCD + CPR)
+  Clock Path Skew:        -0.080ns (DCD - SCD + CPR)
     Destination Clock Delay (DCD):    5.447ns = ( 9.447 - 4.000 ) 
-    Source Clock Delay      (SCD):    5.896ns
-    Clock Pessimism Removal (CPR):    0.343ns
+    Source Clock Delay      (SCD):    5.984ns
+    Clock Pessimism Removal (CPR):    0.458ns
   Clock Uncertainty:      0.063ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
     Discrete Jitter          (DJ):    0.104ns
@@ -687,19 +710,19 @@ Slack (VIOLATED) :        -0.724ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT5
                          net (fo=1, routed)           1.754     4.132    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_pwm_clk/O
-                         net (fo=215, routed)         1.663     5.896    pwm[0]/clk
-    SLICE_X30Y53         FDRE                                         r  pwm[0]/vcnt_r_reg[0]/C
+                         net (fo=215, routed)         1.751     5.984    pwm[0]/clk
+    SLICE_X41Y38         FDRE                                         r  pwm[0]/v_r_reg[1]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X30Y53         FDRE (Prop_fdre_C_Q)         0.518     6.414 r  pwm[0]/vcnt_r_reg[0]/Q
-                         net (fo=2, routed)           0.869     7.284    pwm[0]/vcnt_r[0]
-    SLICE_X30Y52         LUT4 (Prop_lut4_I1_O)        0.124     7.408 r  pwm[0]/pwm_o_i_12/O
-                         net (fo=1, routed)           0.000     7.408    pwm[0]/pwm_o_i_12_n_0
-    SLICE_X30Y52         CARRY4 (Prop_carry4_S[0]_CO[3])
-                                                      0.513     7.921 r  pwm[0]/pwm_o_reg_i_3/CO[3]
-                         net (fo=1, routed)           0.000     7.921    pwm[0]/pwm_o_reg_i_3_n_0
-    SLICE_X30Y53         CARRY4 (Prop_carry4_CI_CO[0])
-                                                      0.254     8.175 r  pwm[0]/pwm_o_reg_i_2/CO[0]
-                         net (fo=1, routed)           1.199     9.374    pwm[0]/p_1_in
+    SLICE_X41Y38         FDRE (Prop_fdre_C_Q)         0.419     6.403 r  pwm[0]/v_r_reg[1]/Q
+                         net (fo=2, routed)           0.817     7.220    pwm[0]/v_r[1]
+    SLICE_X43Y37         LUT4 (Prop_lut4_I2_O)        0.296     7.516 r  pwm[0]/pwm_o_i_12/O
+                         net (fo=1, routed)           0.000     7.516    pwm[0]/pwm_o_i_12_n_0
+    SLICE_X43Y37         CARRY4 (Prop_carry4_S[0]_CO[3])
+                                                      0.532     8.048 r  pwm[0]/pwm_o_reg_i_3/CO[3]
+                         net (fo=1, routed)           0.000     8.048    pwm[0]/pwm_o_reg_i_3_n_0
+    SLICE_X43Y38         CARRY4 (Prop_carry4_CI_CO[0])
+                                                      0.271     8.319 r  pwm[0]/pwm_o_reg_i_2/CO[0]
+                         net (fo=1, routed)           0.845     9.164    pwm[0]/p_1_in
     OLOGIC_X0Y47         FDRE                                         r  pwm[0]/pwm_o_reg/D
   -------------------------------------------------------------------    -------------------
 
@@ -715,14 +738,14 @@ Slack (VIOLATED) :        -0.724ns  (required time - arrival time)
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.091     7.890 r  bufg_pwm_clk/O
                          net (fo=215, routed)         1.557     9.447    pwm[0]/clk
     OLOGIC_X0Y47         FDRE                                         r  pwm[0]/pwm_o_reg/C
-                         clock pessimism              0.343     9.790    
-                         clock uncertainty           -0.063     9.727    
-    OLOGIC_X0Y47         FDRE (Setup_fdre_C_D)       -1.077     8.650    pwm[0]/pwm_o_reg
+                         clock pessimism              0.458     9.905    
+                         clock uncertainty           -0.063     9.842    
+    OLOGIC_X0Y47         FDRE (Setup_fdre_C_D)       -1.083     8.759    pwm[0]/pwm_o_reg
   -------------------------------------------------------------------
-                         required time                          8.650    
-                         arrival time                          -9.374    
+                         required time                          8.759    
+                         arrival time                          -9.164    
   -------------------------------------------------------------------
-                         slack                                 -0.724    
+                         slack                                 -0.406    
 
 
 
@@ -730,20 +753,20 @@ Slack (VIOLATED) :        -0.724ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.071ns  (arrival time - required time)
-  Source:                 pwm[1]/v_reg[5]/C
+Slack (MET) :             0.143ns  (arrival time - required time)
+  Source:                 pwm[2]/b_reg[11]/C
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
-  Destination:            pwm[1]/v_r_reg[8]/D
+  Destination:            pwm[2]/b_reg[10]/D
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_pwm_clk rise@0.000ns - pll_pwm_clk rise@0.000ns)
-  Data Path Delay:        0.438ns  (logic 0.190ns (43.339%)  route 0.248ns (56.661%))
-  Logic Levels:           1  (LUT4=1)
-  Clock Path Skew:        0.260ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.370ns
-    Source Clock Delay      (SCD):    1.979ns
-    Clock Pessimism Removal (CPR):    0.130ns
+  Data Path Delay:        0.277ns  (logic 0.186ns (67.123%)  route 0.091ns (32.877%))
+  Logic Levels:           1  (LUT6=1)
+  Clock Path Skew:        0.013ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.363ns
+    Source Clock Delay      (SCD):    1.970ns
+    Clock Pessimism Removal (CPR):    0.380ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -757,14 +780,14 @@ Slack (MET) :             0.071ns  (arrival time - required time)
                                                       0.051     0.893 r  pll/pll/CLKOUT5
                          net (fo=1, routed)           0.497     1.390    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.026     1.416 r  bufg_pwm_clk/O
-                         net (fo=215, routed)         0.564     1.979    pwm[1]/clk
-    SLICE_X19Y48         FDRE                                         r  pwm[1]/v_reg[5]/C
+                         net (fo=215, routed)         0.555     1.970    pwm[2]/clk
+    SLICE_X35Y30         FDRE                                         r  pwm[2]/b_reg[11]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X19Y48         FDRE (Prop_fdre_C_Q)         0.141     2.120 r  pwm[1]/v_reg[5]/Q
-                         net (fo=4, routed)           0.248     2.369    pwm[1]/v_reg_n_0_[5]
-    SLICE_X23Y47         LUT4 (Prop_lut4_I1_O)        0.049     2.418 r  pwm[1]/v_r[8]_i_1/O
-                         net (fo=1, routed)           0.000     2.418    pwm[1]/v_r[8]_i_1_n_0
-    SLICE_X23Y47         FDRE                                         r  pwm[1]/v_r_reg[8]/D
+    SLICE_X35Y30         FDRE (Prop_fdre_C_Q)         0.141     2.111 r  pwm[2]/b_reg[11]/Q
+                         net (fo=1, routed)           0.091     2.202    pwm[2]/b_reg_n_0_[11]
+    SLICE_X34Y30         LUT6 (Prop_lut6_I0_O)        0.045     2.247 r  pwm[2]/b[10]_i_1/O
+                         net (fo=1, routed)           0.000     2.247    pwm[2]/p_0_in[10]
+    SLICE_X34Y30         FDRE                                         r  pwm[2]/b_reg[10]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -777,15 +800,15 @@ Slack (MET) :             0.071ns  (arrival time - required time)
                                                       0.054     0.968 r  pll/pll/CLKOUT5
                          net (fo=1, routed)           0.544     1.512    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.029     1.541 r  bufg_pwm_clk/O
-                         net (fo=215, routed)         0.829     2.370    pwm[1]/clk
-    SLICE_X23Y47         FDRE                                         r  pwm[1]/v_r_reg[8]/C
-                         clock pessimism             -0.130     2.240    
-    SLICE_X23Y47         FDRE (Hold_fdre_C_D)         0.107     2.347    pwm[1]/v_r_reg[8]
+                         net (fo=215, routed)         0.822     2.363    pwm[2]/clk
+    SLICE_X34Y30         FDRE                                         r  pwm[2]/b_reg[10]/C
+                         clock pessimism             -0.380     1.983    
+    SLICE_X34Y30         FDRE (Hold_fdre_C_D)         0.121     2.104    pwm[2]/b_reg[10]
   -------------------------------------------------------------------
-                         required time                         -2.347    
-                         arrival time                           2.418    
+                         required time                         -2.104    
+                         arrival time                           2.247    
   -------------------------------------------------------------------
-                         slack                                  0.071    
+                         slack                                  0.143    
 
 
 
@@ -801,8 +824,8 @@ Sources:            { pll/pll/CLKOUT5 }
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location        Pin
 Min Period        n/a     BUFG/I             n/a            2.155         4.000       1.845      BUFGCTRL_X0Y2   bufg_pwm_clk/I
 Max Period        n/a     PLLE2_ADV/CLKOUT5  n/a            160.000       4.000       156.000    PLLE2_ADV_X0Y0  pll/pll/CLKOUT5
-Low Pulse Width   Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X14Y50    pwm[0]/b_reg[13]/C
-High Pulse Width  Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X4Y49     pwm[1]/b_reg[8]/C
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X43Y32    pwm_rstn_reg/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         2.000       1.500      SLICE_X43Y32    pwm_rstn_reg/C
 
 
 
@@ -810,27 +833,27 @@ High Pulse Width  Slow    FDRE/C             n/a            0.500         2.000 
 From Clock:  clk_fpga_3
   To Clock:  clk_fpga_3
 
-Setup :          309  Failing Endpoints,  Worst Slack       -2.193ns,  Total Violation     -180.793ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.122ns,  Total Violation        0.000ns
+Setup :           10  Failing Endpoints,  Worst Slack       -0.216ns,  Total Violation       -0.953ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.081ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        1.000ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -2.193ns  (required time - arrival time)
-  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
+Slack (VIOLATED) :        -0.216ns  (required time - arrival time)
+  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
                             (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
-  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/D
-                            (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
+  Destination:            i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[3]
+                            (rising edge-triggered cell XADC clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
   Path Group:             clk_fpga_3
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            5.000ns  (clk_fpga_3 rise@5.000ns - clk_fpga_3 rise@0.000ns)
-  Data Path Delay:        6.905ns  (logic 3.114ns (45.100%)  route 3.791ns (54.900%))
-  Logic Levels:           8  (CARRY4=4 LUT3=2 LUT4=1 LUT5=1)
-  Clock Path Skew:        -0.010ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    2.725ns = ( 7.725 - 5.000 ) 
-    Source Clock Delay      (SCD):    2.965ns
+  Data Path Delay:        4.317ns  (logic 0.966ns (22.374%)  route 3.351ns (77.626%))
+  Logic Levels:           3  (LUT3=1 LUT4=1 LUT6=1)
+  Clock Path Skew:        -0.117ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    2.666ns = ( 7.666 - 5.000 ) 
+    Source Clock Delay      (SCD):    3.013ns
     Clock Pessimism Removal (CPR):    0.230ns
   Clock Uncertainty:      0.083ns  ((TSJ^2 + TIJ^2)^1/2 + DJ) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -845,32 +868,18 @@ Slack (VIOLATED) :        -2.193ns  (required time - arrival time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, routed)           1.207     1.207    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.101     1.308 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, routed)         1.657     2.965    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/ACLK
-    SLICE_X7Y70          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/C
+                         net (fo=751, routed)         1.705     3.013    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/ACLK
+    SLICE_X5Y69          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X7Y70          FDRE (Prop_fdre_C_Q)         0.456     3.421 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/aw_pipe/m_payload_i_reg[39]/Q
-                         net (fo=11, routed)          0.949     4.370    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/s_axburst[1]
-    SLICE_X9Y65          LUT3 (Prop_lut3_I1_O)        0.124     4.494 f  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/next_pending_INST_0/O
-                         net (fo=4, routed)           0.840     5.334    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/next_pending
-    SLICE_X10Y65         LUT5 (Prop_lut5_I3_O)        0.153     5.487 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/next_INST_0/O
-                         net (fo=26, routed)          0.938     6.424    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/next
-    SLICE_X3Y65          LUT4 (Prop_lut4_I3_O)        0.331     6.755 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[0]_i_17/O
-                         net (fo=1, routed)           0.000     6.755    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[0]_i_17_n_0
-    SLICE_X3Y65          CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.550     7.305 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]_i_11/CO[3]
-                         net (fo=1, routed)           0.000     7.305    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]_i_11_n_0
-    SLICE_X3Y66          CARRY4 (Prop_carry4_CI_O[1])
-                                                      0.334     7.639 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_6/O[1]
-                         net (fo=1, routed)           0.595     8.235    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/C[5]
-    SLICE_X2Y66          LUT3 (Prop_lut3_I0_O)        0.303     8.538 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[4]_i_4/O
-                         net (fo=1, routed)           0.000     8.538    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[4]_i_4_n_0
-    SLICE_X2Y66          CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.550     9.088 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_1/CO[3]
-                         net (fo=1, routed)           0.000     9.088    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_1_n_0
-    SLICE_X2Y67          CARRY4 (Prop_carry4_CI_O[3])
-                                                      0.313     9.401 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]_i_1/O[3]
-                         net (fo=1, routed)           0.469     9.870    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]_i_1_n_4
-    SLICE_X4Y67          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/D
+    SLICE_X5Y69          FDRE (Prop_fdre_C_Q)         0.419     3.432 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/SI_REG/ar.ar_pipe/m_payload_i_reg[5]/Q
+                         net (fo=7, routed)           0.901     4.333    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/axaddr[5]
+    SLICE_X3Y73          LUT3 (Prop_lut3_I0_O)        0.299     4.632 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/cmd_byte_addr[5]_INST_0/O
+                         net (fo=1, routed)           0.617     5.250    i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/lopt_50
+    SLICE_X2Y74          LUT6 (Prop_lut6_I3_O)        0.124     5.374 r  i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/Bus2IP_Addr[5]_INST_0_LOPT_REMAP/O
+                         net (fo=1, routed)           0.815     6.189    i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/xlnx_opt_Bus2IP_Addr[5]_1
+    SLICE_X4Y72          LUT4 (Prop_lut4_I0_O)        0.124     6.313 r  i_ps/system_i/system_i/xadc/inst/AXI_LITE_IPIF_I/I_SLAVE_ATTACHMENT/Bus2IP_Addr[5]_INST_0_LOPT_REMAP_2_comp/O
+                         net (fo=18, routed)          1.017     7.330    i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/Bus2IP_Addr[5]
+    XADC_X0Y0            XADC                                         r  i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DADDR[3]
   -------------------------------------------------------------------    -------------------
 
                          (clock clk_fpga_3 rise edge)
@@ -878,16 +887,17 @@ Slack (VIOLATED) :        -2.193ns  (required time - arrival time)
     PS7_X0Y0             PS7                          0.000     5.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, routed)           1.101     6.101    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.091     6.192 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, routed)         1.533     7.725    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/clk
-    SLICE_X4Y67          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]/C
-                         clock pessimism              0.230     7.955    
-                         clock uncertainty           -0.083     7.872    
-    SLICE_X4Y67          FDRE (Setup_fdre_C_D)       -0.195     7.677    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[11]
+                         net (fo=751, routed)         1.474     7.666    i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/Bus2IP_Clk
+    XADC_X0Y0            XADC                                         r  i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DCLK
+                         clock pessimism              0.230     7.896    
+                         clock uncertainty           -0.083     7.813    
+    XADC_X0Y0            XADC (Setup_xadc_DCLK_DADDR[3])
+                                                     -0.699     7.114    i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST
   -------------------------------------------------------------------
-                         required time                          7.677    
-                         arrival time                          -9.870    
+                         required time                          7.114    
+                         arrival time                          -7.330    
   -------------------------------------------------------------------
-                         slack                                 -2.193    
+                         slack                                 -0.216    
 
 
 
@@ -895,20 +905,20 @@ Slack (VIOLATED) :        -2.193ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.122ns  (arrival time - required time)
-  Source:                 i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/C
+Slack (MET) :             0.081ns  (arrival time - required time)
+  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/r_arid_r_reg[7]/C
                             (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
-  Destination:            i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/D
-                            (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
+  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][8]_srl32/D
+                            (rising edge-triggered cell SRLC32E clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
   Path Group:             clk_fpga_3
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (clk_fpga_3 rise@0.000ns - clk_fpga_3 rise@0.000ns)
-  Data Path Delay:        0.197ns  (logic 0.141ns (71.611%)  route 0.056ns (28.389%))
+  Data Path Delay:        0.280ns  (logic 0.164ns (58.537%)  route 0.116ns (41.463%))
   Logic Levels:           0  
-  Clock Path Skew:        0.000ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    1.221ns
-    Source Clock Delay      (SCD):    0.923ns
-    Clock Pessimism Removal (CPR):    0.298ns
+  Clock Path Skew:        0.016ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    1.202ns
+    Source Clock Delay      (SCD):    0.904ns
+    Clock Pessimism Removal (CPR):    0.282ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
   -------------------------------------------------------------------    -------------------
@@ -917,12 +927,12 @@ Slack (MET) :             0.122ns  (arrival time - required time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, routed)           0.315     0.315    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.026     0.341 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, routed)         0.582     0.923    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/scndry_aclk
-    SLICE_X3Y59          FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/C
+                         net (fo=751, routed)         0.563     0.904    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/clk
+    SLICE_X6Y58          FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/r_arid_r_reg[7]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X3Y59          FDRE (Prop_fdre_C_Q)         0.141     1.064 r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/Q
-                         net (fo=1, routed)           0.056     1.119    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/D
-    SLICE_X3Y59          FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/D
+    SLICE_X6Y58          FDRE (Prop_fdre_C_Q)         0.164     1.068 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/r_arid_r_reg[7]/Q
+                         net (fo=1, routed)           0.116     1.184    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/din[8]
+    SLICE_X6Y57          SRLC32E                                      r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][8]_srl32/D
   -------------------------------------------------------------------    -------------------
 
                          (clock clk_fpga_3 rise edge)
@@ -930,15 +940,16 @@ Slack (MET) :             0.122ns  (arrival time - required time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, routed)           0.341     0.341    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
     BUFGCTRL_X0Y1        BUFG (Prop_bufg_I_O)         0.029     0.370 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=851, routed)         0.851     1.221    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/scndry_aclk
-    SLICE_X3Y59          FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/C
-                         clock pessimism             -0.298     0.923    
-    SLICE_X3Y59          FDRE (Hold_fdre_C_D)         0.075     0.998    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2
+                         net (fo=751, routed)         0.832     1.202    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/clk
+    SLICE_X6Y57          SRLC32E                                      r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][8]_srl32/CLK
+                         clock pessimism             -0.282     0.920    
+    SLICE_X6Y57          SRLC32E (Hold_srlc32e_CLK_D)
+                                                      0.183     1.103    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/memory_reg[31][8]_srl32
   -------------------------------------------------------------------
-                         required time                         -0.998    
-                         arrival time                           1.119    
+                         required time                         -1.103    
+                         arrival time                           1.184    
   -------------------------------------------------------------------
-                         slack                                  0.122    
+                         slack                                  0.081    
 
 
 
@@ -953,8 +964,8 @@ Sources:            { i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKC
 
 Check Type        Corner  Lib Pin      Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location     Pin
 Min Period        n/a     XADC/DCLK    n/a            4.000         5.000       1.000      XADC_X0Y0    i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DCLK
-Low Pulse Width   Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X4Y54  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][10]_srl32/CLK
-High Pulse Width  Fast    SRL16E/CLK   n/a            0.980         2.500       1.520      SLICE_X0Y78  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/POR_SRL_I/CLK
+Low Pulse Width   Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X6Y65  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
+High Pulse Width  Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520      SLICE_X6Y65  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
 
 
 
@@ -962,14 +973,14 @@ High Pulse Width  Fast    SRL16E/CLK   n/a            0.980         2.500       
 From Clock:  adc_clk
   To Clock:  pll_adc_clk
 
-Setup :            0  Failing Endpoints,  Worst Slack        5.940ns,  Total Violation        0.000ns
-Hold  :           28  Failing Endpoints,  Worst Slack       -2.163ns,  Total Violation      -58.853ns
+Setup :            0  Failing Endpoints,  Worst Slack        5.939ns,  Total Violation        0.000ns
+Hold  :           28  Failing Endpoints,  Worst Slack       -2.162ns,  Total Violation      -58.825ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             5.940ns  (required time - arrival time)
+Slack (MET) :             5.939ns  (required time - arrival time)
   Source:                 adc_dat_a_i[7]
                             (input port clocked by adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            adc_dat_a_reg[5]/D
@@ -1010,16 +1021,16 @@ Slack (MET) :             5.940ns  (required time - arrival time)
                                                       0.051     8.893 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           0.497     9.390    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     9.416 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       0.580     9.995    adc_clk
+                         net (fo=13385, routed)       0.580     9.995    adc_clk
     ILOGIC_X0Y33         FDRE                                         r  adc_dat_a_reg[5]/C
                          clock pessimism              0.000     9.995    
                          clock uncertainty           -0.166     9.829    
-    ILOGIC_X0Y33         FDRE (Setup_fdre_C_D)       -0.001     9.828    adc_dat_a_reg[5]
+    ILOGIC_X0Y33         FDRE (Setup_fdre_C_D)       -0.002     9.827    adc_dat_a_reg[5]
   -------------------------------------------------------------------
-                         required time                          9.828    
+                         required time                          9.827    
                          arrival time                          -3.888    
   -------------------------------------------------------------------
-                         slack                                  5.940    
+                         slack                                  5.939    
 
 
 
@@ -1027,7 +1038,7 @@ Slack (MET) :             5.940ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -2.163ns  (arrival time - required time)
+Slack (VIOLATED) :        -2.162ns  (arrival time - required time)
   Source:                 adc_dat_b_i[3]
                             (input port clocked by adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            adc_dat_b_reg[1]/D
@@ -1068,16 +1079,16 @@ Slack (VIOLATED) :        -2.163ns  (arrival time - required time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       1.777     6.011    adc_clk
+                         net (fo=13385, routed)       1.777     6.011    adc_clk
     ILOGIC_X0Y1          FDRE                                         r  adc_dat_b_reg[1]/C
                          clock pessimism              0.000     6.011    
                          clock uncertainty            0.166     6.176    
-    ILOGIC_X0Y1          FDRE (Hold_fdre_C_D)         0.192     6.368    adc_dat_b_reg[1]
+    ILOGIC_X0Y1          FDRE (Hold_fdre_C_D)         0.191     6.367    adc_dat_b_reg[1]
   -------------------------------------------------------------------
-                         required time                         -6.368    
+                         required time                         -6.367    
                          arrival time                           4.205    
   -------------------------------------------------------------------
-                         slack                                 -2.163    
+                         slack                                 -2.162    
 
 
 
@@ -1087,26 +1098,26 @@ Slack (VIOLATED) :        -2.163ns  (arrival time - required time)
 From Clock:  pll_adc_clk
   To Clock:  pll_dac_clk_1x
 
-Setup :            0  Failing Endpoints,  Worst Slack        3.061ns,  Total Violation        0.000ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.275ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        2.743ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.198ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             3.061ns  (required time - arrival time)
-  Source:                 i_dsp/sum1_reg[13]/C
+Slack (MET) :             2.743ns  (required time - arrival time)
+  Source:                 i_dsp/sum2_reg[14]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            dac_dat_a_reg[0]/D
+  Destination:            dac_dat_b_reg[12]/D
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_dac_clk_1x
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            8.000ns  (pll_dac_clk_1x rise@8.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        4.410ns  (logic 0.718ns (16.280%)  route 3.692ns (83.720%))
+  Data Path Delay:        4.644ns  (logic 0.580ns (12.489%)  route 4.064ns (87.511%))
   Logic Levels:           1  (LUT6=1)
-  Clock Path Skew:        -0.272ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.451ns = ( 13.451 - 8.000 ) 
-    Source Clock Delay      (SCD):    5.896ns
+  Clock Path Skew:        -0.357ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.452ns = ( 13.452 - 8.000 ) 
+    Source Clock Delay      (SCD):    5.982ns
     Clock Pessimism Removal (CPR):    0.173ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1125,14 +1136,14 @@ Slack (MET) :             3.061ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       1.663     5.896    i_dsp/clk_i
-    SLICE_X29Y53         FDRE                                         r  i_dsp/sum1_reg[13]/C
+                         net (fo=13385, routed)       1.749     5.982    i_dsp/clk_i
+    SLICE_X39Y38         FDRE                                         r  i_dsp/sum2_reg[14]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X29Y53         FDRE (Prop_fdre_C_Q)         0.419     6.315 f  i_dsp/sum1_reg[13]/Q
-                         net (fo=14, routed)          1.111     7.426    i_dsp/dac_saturate[0]/input_i[13]
-    SLICE_X26Y48         LUT6 (Prop_lut6_I2_O)        0.299     7.725 r  i_dsp/dac_saturate[0]/output_o[0]_INST_0/O
-                         net (fo=13, routed)          2.581    10.307    dac_dat_a[0]_i_1_n_0
-    SLICE_X41Y86         FDRE                                         r  dac_dat_a_reg[0]/D
+    SLICE_X39Y38         FDRE (Prop_fdre_C_Q)         0.456     6.438 f  i_dsp/sum2_reg[14]/Q
+                         net (fo=14, routed)          1.295     7.733    i_dsp/dac_saturate[1]/input_i[14]
+    SLICE_X43Y35         LUT6 (Prop_lut6_I1_O)        0.124     7.857 r  i_dsp/dac_saturate[1]/output_o[12]_INST_0/O
+                         net (fo=15, routed)          2.769    10.626    dac_dat_b[12]_i_1_n_0
+    SLICE_X43Y87         FDRE                                         r  dac_dat_b_reg[12]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_dac_clk_1x rise edge)
@@ -1145,16 +1156,16 @@ Slack (MET) :             3.061ns  (required time - arrival time)
                                                       0.084    10.205 r  pll/pll/CLKOUT1
                          net (fo=1, routed)           1.594    11.799    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.091    11.890 r  bufg_dac_clk_1x/O
-                         net (fo=45, routed)          1.561    13.451    dac_clk_1x
-    SLICE_X41Y86         FDRE                                         r  dac_dat_a_reg[0]/C
-                         clock pessimism              0.173    13.624    
-                         clock uncertainty           -0.189    13.435    
-    SLICE_X41Y86         FDRE (Setup_fdre_C_D)       -0.067    13.368    dac_dat_a_reg[0]
+                         net (fo=45, routed)          1.562    13.452    dac_clk_1x
+    SLICE_X43Y87         FDRE                                         r  dac_dat_b_reg[12]/C
+                         clock pessimism              0.173    13.625    
+                         clock uncertainty           -0.189    13.436    
+    SLICE_X43Y87         FDRE (Setup_fdre_C_D)       -0.067    13.369    dac_dat_b_reg[12]
   -------------------------------------------------------------------
-                         required time                         13.368    
-                         arrival time                         -10.307    
+                         required time                         13.369    
+                         arrival time                         -10.626    
   -------------------------------------------------------------------
-                         slack                                  3.061    
+                         slack                                  2.743    
 
 
 
@@ -1162,19 +1173,19 @@ Slack (MET) :             3.061ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.275ns  (arrival time - required time)
-  Source:                 i_dsp/sum2_reg[11]/C
+Slack (MET) :             0.198ns  (arrival time - required time)
+  Source:                 i_dsp/sum1_reg[17]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            dac_dat_b_reg[11]/D
+  Destination:            dac_dat_a_reg[7]/D
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_dac_clk_1x
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_dac_clk_1x rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.846ns  (logic 0.209ns (24.703%)  route 0.637ns (75.297%))
+  Data Path Delay:        0.776ns  (logic 0.209ns (26.922%)  route 0.567ns (73.078%))
   Logic Levels:           1  (LUT6=1)
-  Clock Path Skew:        0.312ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.391ns
-    Source Clock Delay      (SCD):    2.003ns
+  Clock Path Skew:        0.320ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.401ns
+    Source Clock Delay      (SCD):    2.006ns
     Clock Pessimism Removal (CPR):    0.075ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1193,14 +1204,14 @@ Slack (MET) :             0.275ns  (arrival time - required time)
                                                       0.051     0.893 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           0.497     1.390    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     1.416 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       0.588     2.003    i_dsp/clk_i
-    SLICE_X38Y55         FDRE                                         r  i_dsp/sum2_reg[11]/C
+                         net (fo=13385, routed)       0.591     2.006    i_dsp/clk_i
+    SLICE_X42Y41         FDRE                                         r  i_dsp/sum1_reg[17]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X38Y55         FDRE (Prop_fdre_C_Q)         0.164     2.167 f  i_dsp/sum2_reg[11]/Q
-                         net (fo=1, routed)           0.203     2.370    i_dsp/dac_saturate[1]/input_i[11]
-    SLICE_X37Y54         LUT6 (Prop_lut6_I0_O)        0.045     2.415 r  i_dsp/dac_saturate[1]/output_o[11]_INST_0/O
-                         net (fo=15, routed)          0.434     2.849    dac_dat_b[11]_i_1_n_0
-    SLICE_X41Y69         FDRE                                         r  dac_dat_b_reg[11]/D
+    SLICE_X42Y41         FDRE (Prop_fdre_C_Q)         0.164     2.170 r  i_dsp/sum1_reg[17]/Q
+                         net (fo=29, routed)          0.166     2.336    i_dsp/dac_saturate[0]/input_i[17]
+    SLICE_X43Y42         LUT6 (Prop_lut6_I5_O)        0.045     2.381 r  i_dsp/dac_saturate[0]/output_o[7]_INST_0/O
+                         net (fo=15, routed)          0.401     2.782    dac_dat_a[7]_i_1_n_0
+    SLICE_X43Y55         FDRE                                         r  dac_dat_a_reg[7]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_dac_clk_1x rise edge)
@@ -1213,16 +1224,16 @@ Slack (MET) :             0.275ns  (arrival time - required time)
                                                       0.054     0.968 r  pll/pll/CLKOUT1
                          net (fo=1, routed)           0.544     1.512    pll_dac_clk_1x
     BUFGCTRL_X0Y3        BUFG (Prop_bufg_I_O)         0.029     1.541 r  bufg_dac_clk_1x/O
-                         net (fo=45, routed)          0.850     2.391    dac_clk_1x
-    SLICE_X41Y69         FDRE                                         r  dac_dat_b_reg[11]/C
-                         clock pessimism             -0.075     2.316    
-                         clock uncertainty            0.189     2.505    
-    SLICE_X41Y69         FDRE (Hold_fdre_C_D)         0.070     2.575    dac_dat_b_reg[11]
+                         net (fo=45, routed)          0.860     2.401    dac_clk_1x
+    SLICE_X43Y55         FDRE                                         r  dac_dat_a_reg[7]/C
+                         clock pessimism             -0.075     2.326    
+                         clock uncertainty            0.189     2.515    
+    SLICE_X43Y55         FDRE (Hold_fdre_C_D)         0.070     2.585    dac_dat_a_reg[7]
   -------------------------------------------------------------------
-                         required time                         -2.575    
-                         arrival time                           2.849    
+                         required time                         -2.585    
+                         arrival time                           2.782    
   -------------------------------------------------------------------
-                         slack                                  0.275    
+                         slack                                  0.198    
 
 
 
@@ -1232,26 +1243,26 @@ Slack (MET) :             0.275ns  (arrival time - required time)
 From Clock:  pll_adc_clk
   To Clock:  pll_pwm_clk
 
-Setup :            0  Failing Endpoints,  Worst Slack        0.272ns,  Total Violation        0.000ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.188ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        0.392ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.128ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.272ns  (required time - arrival time)
-  Source:                 i_ams/dac_c_o_reg[8]/C
+Slack (MET) :             0.392ns  (required time - arrival time)
+  Source:                 i_ams/dac_b_o_reg[14]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            pwm[2]/b_reg[8]/D
+  Destination:            pwm[1]/b_reg[14]/D
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_pwm_clk rise@4.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        3.225ns  (logic 0.718ns (22.267%)  route 2.507ns (77.733%))
-  Logic Levels:           1  (LUT6=1)
-  Clock Path Skew:        -0.346ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    5.378ns = ( 9.378 - 4.000 ) 
-    Source Clock Delay      (SCD):    5.897ns
+  Data Path Delay:        3.092ns  (logic 0.580ns (18.757%)  route 2.512ns (81.243%))
+  Logic Levels:           1  (LUT5=1)
+  Clock Path Skew:        -0.269ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    5.459ns = ( 9.459 - 4.000 ) 
+    Source Clock Delay      (SCD):    5.901ns
     Clock Pessimism Removal (CPR):    0.173ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1270,14 +1281,14 @@ Slack (MET) :             0.272ns  (required time - arrival time)
                                                       0.089     2.378 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           1.754     4.132    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.101     4.233 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       1.664     5.897    i_ams/clk_i
-    SLICE_X19Y50         FDRE                                         r  i_ams/dac_c_o_reg[8]/C
+                         net (fo=13385, routed)       1.668     5.901    i_ams/clk_i
+    SLICE_X27Y36         FDRE                                         r  i_ams/dac_b_o_reg[14]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X19Y50         FDRE (Prop_fdre_C_Q)         0.419     6.316 r  i_ams/dac_c_o_reg[8]/Q
-                         net (fo=2, routed)           2.507     8.823    pwm[2]/cfg[8]
-    SLICE_X29Y20         LUT6 (Prop_lut6_I5_O)        0.299     9.122 r  pwm[2]/b[8]_i_1/O
-                         net (fo=1, routed)           0.000     9.122    pwm[2]/b[8]_i_1_n_0
-    SLICE_X29Y20         FDRE                                         r  pwm[2]/b_reg[8]/D
+    SLICE_X27Y36         FDRE (Prop_fdre_C_Q)         0.456     6.357 r  i_ams/dac_b_o_reg[14]/Q
+                         net (fo=2, routed)           1.533     7.891    pwm[1]/cfg[14]
+    SLICE_X39Y36         LUT5 (Prop_lut5_I0_O)        0.124     8.015 r  pwm[1]/b[14]_i_2/O
+                         net (fo=1, routed)           0.979     8.993    pwm[1]/p_0_in[14]
+    SLICE_X37Y34         FDRE                                         r  pwm[1]/b_reg[14]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -1290,16 +1301,16 @@ Slack (MET) :             0.272ns  (required time - arrival time)
                                                       0.084     6.205 r  pll/pll/CLKOUT5
                          net (fo=1, routed)           1.594     7.799    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.091     7.890 r  bufg_pwm_clk/O
-                         net (fo=215, routed)         1.488     9.378    pwm[2]/clk
-    SLICE_X29Y20         FDRE                                         r  pwm[2]/b_reg[8]/C
-                         clock pessimism              0.173     9.552    
-                         clock uncertainty           -0.189     9.363    
-    SLICE_X29Y20         FDRE (Setup_fdre_C_D)        0.031     9.394    pwm[2]/b_reg[8]
+                         net (fo=215, routed)         1.569     9.459    pwm[1]/clk
+    SLICE_X37Y34         FDRE                                         r  pwm[1]/b_reg[14]/C
+                         clock pessimism              0.173     9.633    
+                         clock uncertainty           -0.189     9.444    
+    SLICE_X37Y34         FDRE (Setup_fdre_C_D)       -0.058     9.386    pwm[1]/b_reg[14]
   -------------------------------------------------------------------
-                         required time                          9.394    
-                         arrival time                          -9.122    
+                         required time                          9.386    
+                         arrival time                          -8.993    
   -------------------------------------------------------------------
-                         slack                                  0.272    
+                         slack                                  0.392    
 
 
 
@@ -1307,19 +1318,19 @@ Slack (MET) :             0.272ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.188ns  (arrival time - required time)
-  Source:                 i_ams/dac_a_o_reg[23]/C
+Slack (MET) :             0.128ns  (arrival time - required time)
+  Source:                 i_ams/dac_c_o_reg[9]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            pwm[0]/v_reg[7]/D
+  Destination:            pwm[2]/b_reg[9]/D
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Path Group:             pll_pwm_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_pwm_clk rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.707ns  (logic 0.128ns (18.117%)  route 0.579ns (81.883%))
-  Logic Levels:           0  
-  Clock Path Skew:        0.319ns (DCD - SCD - CPR)
-    Destination Clock Delay (DCD):    2.372ns
-    Source Clock Delay      (SCD):    1.977ns
+  Data Path Delay:        0.750ns  (logic 0.209ns (27.856%)  route 0.541ns (72.144%))
+  Logic Levels:           1  (LUT6=1)
+  Clock Path Skew:        0.312ns (DCD - SCD - CPR)
+    Destination Clock Delay (DCD):    2.363ns
+    Source Clock Delay      (SCD):    1.975ns
     Clock Pessimism Removal (CPR):    0.075ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1338,12 +1349,14 @@ Slack (MET) :             0.188ns  (arrival time - required time)
                                                       0.051     0.893 r  pll/pll/CLKOUT0
                          net (fo=1, routed)           0.497     1.390    pll_adc_clk
     BUFGCTRL_X0Y0        BUFG (Prop_bufg_I_O)         0.026     1.416 r  bufg_adc_clk/O
-                         net (fo=13384, routed)       0.562     1.977    i_ams/clk_i
-    SLICE_X18Y52         FDRE                                         r  i_ams/dac_a_o_reg[23]/C
+                         net (fo=13385, routed)       0.560     1.975    i_ams/clk_i
+    SLICE_X30Y37         FDRE                                         r  i_ams/dac_c_o_reg[9]/C
   -------------------------------------------------------------------    -------------------
-    SLICE_X18Y52         FDRE (Prop_fdre_C_Q)         0.128     2.105 r  i_ams/dac_a_o_reg[23]/Q
-                         net (fo=2, routed)           0.579     2.684    pwm[0]/cfg[23]
-    SLICE_X16Y50         FDRE                                         r  pwm[0]/v_reg[7]/D
+    SLICE_X30Y37         FDRE (Prop_fdre_C_Q)         0.164     2.139 r  i_ams/dac_c_o_reg[9]/Q
+                         net (fo=2, routed)           0.541     2.680    pwm[2]/cfg[9]
+    SLICE_X34Y30         LUT6 (Prop_lut6_I5_O)        0.045     2.725 r  pwm[2]/b[9]_i_1/O
+                         net (fo=1, routed)           0.000     2.725    pwm[2]/p_0_in[9]
+    SLICE_X34Y30         FDRE                                         r  pwm[2]/b_reg[9]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_pwm_clk rise edge)
@@ -1356,16 +1369,16 @@ Slack (MET) :             0.188ns  (arrival time - required time)
                                                       0.054     0.968 r  pll/pll/CLKOUT5
                          net (fo=1, routed)           0.544     1.512    pll_pwm_clk
     BUFGCTRL_X0Y2        BUFG (Prop_bufg_I_O)         0.029     1.541 r  bufg_pwm_clk/O
-                         net (fo=215, routed)         0.831     2.372    pwm[0]/clk
-    SLICE_X16Y50         FDRE                                         r  pwm[0]/v_reg[7]/C
-                         clock pessimism             -0.075     2.297    
-                         clock uncertainty            0.189     2.486    
-    SLICE_X16Y50         FDRE (Hold_fdre_C_D)         0.010     2.496    pwm[0]/v_reg[7]
+                         net (fo=215, routed)         0.822     2.363    pwm[2]/clk
+    SLICE_X34Y30         FDRE                                         r  pwm[2]/b_reg[9]/C
+                         clock pessimism             -0.075     2.288    
+                         clock uncertainty            0.189     2.477    
+    SLICE_X34Y30         FDRE (Hold_fdre_C_D)         0.121     2.598    pwm[2]/b_reg[9]
   -------------------------------------------------------------------
-                         required time                         -2.496    
-                         arrival time                           2.684    
+                         required time                         -2.598    
+                         arrival time                           2.725    
   -------------------------------------------------------------------
-                         slack                                  0.188    
+                         slack                                  0.128    
 
 
 

--- a/pyrpl/fpga/out/post_route_util.rpt
+++ b/pyrpl/fpga/out/post_route_util.rpt
@@ -1,13 +1,14 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-------------------------------------------------------------------------------------
-| Tool Version : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date         : Fri Mar 17 14:13:56 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:33:48 2025
 | Host         : fontana running 64-bit major release  (build 9200)
 | Command      : report_utilization -file out/post_route_util.rpt
 | Design       : red_pitaya_top
-| Device       : 7z010clg400-1
+| Device       : xc7z010clg400-1
+| Speed File   : -1
 | Design State : Routed
-------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Utilization Design Information
 
@@ -28,20 +29,21 @@ Table of Contents
 1. Slice Logic
 --------------
 
-+----------------------------+-------+-------+-----------+-------+
-|          Site Type         |  Used | Fixed | Available | Util% |
-+----------------------------+-------+-------+-----------+-------+
-| Slice LUTs                 | 16735 |     0 |     17600 | 95.09 |
-|   LUT as Logic             | 16648 |     0 |     17600 | 94.59 |
-|   LUT as Memory            |    87 |     0 |      6000 |  1.45 |
-|     LUT as Distributed RAM |    24 |     0 |           |       |
-|     LUT as Shift Register  |    63 |     0 |           |       |
-| Slice Registers            | 14235 |     0 |     35200 | 40.44 |
-|   Register as Flip Flop    | 14235 |     0 |     35200 | 40.44 |
-|   Register as Latch        |     0 |     0 |     35200 |  0.00 |
-| F7 Muxes                   |   388 |     0 |      8800 |  4.41 |
-| F8 Muxes                   |   178 |     0 |      4400 |  4.05 |
-+----------------------------+-------+-------+-----------+-------+
++----------------------------+-------+-------+------------+-----------+-------+
+|          Site Type         |  Used | Fixed | Prohibited | Available | Util% |
++----------------------------+-------+-------+------------+-----------+-------+
+| Slice LUTs                 | 16084 |     0 |          0 |     17600 | 91.39 |
+|   LUT as Logic             | 16041 |     0 |          0 |     17600 | 91.14 |
+|   LUT as Memory            |    43 |     0 |          0 |      6000 |  0.72 |
+|     LUT as Distributed RAM |     0 |     0 |            |           |       |
+|     LUT as Shift Register  |    43 |     0 |            |           |       |
+| Slice Registers            | 14204 |     0 |          0 |     35200 | 40.35 |
+|   Register as Flip Flop    | 14204 |     0 |          0 |     35200 | 40.35 |
+|   Register as Latch        |     0 |     0 |          0 |     35200 |  0.00 |
+| F7 Muxes                   |   392 |     0 |          0 |      8800 |  4.45 |
+| F8 Muxes                   |   164 |     0 |          0 |      4400 |  3.73 |
++----------------------------+-------+-------+------------+-----------+-------+
+* Warning! LUT value is adjusted to account for LUT combining.
 
 
 1.1 Summary of Registers by Type
@@ -58,127 +60,128 @@ Table of Contents
 | 0     |          Yes |           - |            - |
 | 0     |          Yes |           - |          Set |
 | 0     |          Yes |           - |        Reset |
-| 354   |          Yes |         Set |            - |
-| 13913 |          Yes |       Reset |            - |
+| 322   |          Yes |         Set |            - |
+| 13914 |          Yes |       Reset |            - |
 +-------+--------------+-------------+--------------+
 
 
 2. Slice Logic Distribution
 ---------------------------
 
-+-------------------------------------------------------------+-----------+-------+-----------+--------+
-|                          Site Type                          |    Used   | Fixed | Available |  Util% |
-+-------------------------------------------------------------+-----------+-------+-----------+--------+
-| Slice                                                       |      4400 |     0 |      4400 | 100.00 |
-|   SLICEL                                                    |      2900 |     0 |           |        |
-|   SLICEM                                                    |      1500 |     0 |           |        |
-| LUT as Logic                                                |     16648 |     0 |     17600 |  94.59 |
-|   using O5 output only                                      |         1 |       |           |        |
-|   using O6 output only                                      |     13934 |       |           |        |
-|   using O5 and O6                                           |      2713 |       |           |        |
-| LUT as Memory                                               |        87 |     0 |      6000 |   1.45 |
-|   LUT as Distributed RAM                                    |        24 |     0 |           |        |
-|     using O5 output only                                    |         0 |       |           |        |
-|     using O6 output only                                    |         0 |       |           |        |
-|     using O5 and O6                                         |        24 |       |           |        |
-|   LUT as Shift Register                                     |        63 |     0 |           |        |
-|     using O5 output only                                    |         0 |       |           |        |
-|     using O6 output only                                    |        55 |       |           |        |
-|     using O5 and O6                                         |         8 |       |           |        |
-| LUT Flip Flop Pairs                                         |     17359 |     0 |     17600 |  98.63 |
-|   fully used LUT-FF pairs                                   |     12052 |       |           |        |
-|   LUT-FF pairs with unused LUT                              |       625 |       |           |        |
-|   LUT-FF pairs with unused Flip Flop                        |      4682 |       |           |        |
-| Unique Control Sets                                         |       424 |       |           |        |
-| Minimum number of registers lost to control set restriction | 909(Lost) |       |           |        |
-+-------------------------------------------------------------+-----------+-------+-----------+--------+
++--------------------------------------------+-------+-------+------------+-----------+-------+
+|                  Site Type                 |  Used | Fixed | Prohibited | Available | Util% |
++--------------------------------------------+-------+-------+------------+-----------+-------+
+| Slice                                      |  4398 |     0 |          0 |      4400 | 99.95 |
+|   SLICEL                                   |  2899 |     0 |            |           |       |
+|   SLICEM                                   |  1499 |     0 |            |           |       |
+| LUT as Logic                               | 16041 |     0 |          0 |     17600 | 91.14 |
+|   using O5 output only                     |    10 |       |            |           |       |
+|   using O6 output only                     | 13788 |       |            |           |       |
+|   using O5 and O6                          |  2243 |       |            |           |       |
+| LUT as Memory                              |    43 |     0 |          0 |      6000 |  0.72 |
+|   LUT as Distributed RAM                   |     0 |     0 |            |           |       |
+|     using O5 output only                   |     0 |       |            |           |       |
+|     using O6 output only                   |     0 |       |            |           |       |
+|     using O5 and O6                        |     0 |       |            |           |       |
+|   LUT as Shift Register                    |    43 |     0 |            |           |       |
+|     using O5 output only                   |     0 |       |            |           |       |
+|     using O6 output only                   |    35 |       |            |           |       |
+|     using O5 and O6                        |     8 |       |            |           |       |
+| Slice Registers                            | 14204 |     0 |          0 |     35200 | 40.35 |
+|   Register driven from within the Slice    |  6517 |       |            |           |       |
+|   Register driven from outside the Slice   |  7687 |       |            |           |       |
+|     LUT in front of the register is unused |  1393 |       |            |           |       |
+|     LUT in front of the register is used   |  6294 |       |            |           |       |
+| Unique Control Sets                        |   560 |       |          0 |      4400 | 12.73 |
++--------------------------------------------+-------+-------+------------+-----------+-------+
+* * Note: Available Control Sets calculated as Slice * 1, Review the Control Sets Report for more information regarding control sets.
 
 
 3. Memory
 ---------
 
-+-------------------+------+-------+-----------+-------+
-|     Site Type     | Used | Fixed | Available | Util% |
-+-------------------+------+-------+-----------+-------+
-| Block RAM Tile    |   34 |     0 |        60 | 56.67 |
-|   RAMB36/FIFO*    |   34 |     0 |        60 | 56.67 |
-|     RAMB36E1 only |   34 |       |           |       |
-|   RAMB18          |    0 |     0 |       120 |  0.00 |
-+-------------------+------+-------+-----------+-------+
++-------------------+------+-------+------------+-----------+-------+
+|     Site Type     | Used | Fixed | Prohibited | Available | Util% |
++-------------------+------+-------+------------+-----------+-------+
+| Block RAM Tile    |   34 |     0 |          0 |        60 | 56.67 |
+|   RAMB36/FIFO*    |   34 |     0 |          0 |        60 | 56.67 |
+|     RAMB36E1 only |   34 |       |            |           |       |
+|   RAMB18          |    0 |     0 |          0 |       120 |  0.00 |
++-------------------+------+-------+------------+-----------+-------+
 * Note: Each Block RAM Tile only has one FIFO logic available and therefore can accommodate only one FIFO36E1 or one FIFO18E1. However, if a FIFO18E1 occupies a Block RAM Tile, that tile can still accommodate a RAMB18E1
 
 
 4. DSP
 ------
 
-+----------------+------+-------+-----------+-------+
-|    Site Type   | Used | Fixed | Available | Util% |
-+----------------+------+-------+-----------+-------+
-| DSPs           |   46 |     0 |        80 | 57.50 |
-|   DSP48E1 only |   46 |       |           |       |
-+----------------+------+-------+-----------+-------+
++----------------+------+-------+------------+-----------+-------+
+|    Site Type   | Used | Fixed | Prohibited | Available | Util% |
++----------------+------+-------+------------+-----------+-------+
+| DSPs           |   46 |     0 |          0 |        80 | 57.50 |
+|   DSP48E1 only |   46 |       |            |           |       |
++----------------+------+-------+------------+-----------+-------+
 
 
 5. IO and GT Specific
 ---------------------
 
-+-----------------------------+------+-------+-----------+--------+
-|          Site Type          | Used | Fixed | Available |  Util% |
-+-----------------------------+------+-------+-----------+--------+
-| Bonded IOB                  |   93 |    93 |       100 |  93.00 |
-|   IOB Master Pads           |   44 |       |           |        |
-|   IOB Slave Pads            |   45 |       |           |        |
-|   IOB Flip Flops            |   32 |    32 |           |        |
-| Bonded IPADs                |    2 |     2 |         2 | 100.00 |
-| Bonded IOPADs               |  130 |   130 |       130 | 100.00 |
-| PHY_CONTROL                 |    0 |     0 |         2 |   0.00 |
-| PHASER_REF                  |    0 |     0 |         2 |   0.00 |
-| OUT_FIFO                    |    0 |     0 |         8 |   0.00 |
-| IN_FIFO                     |    0 |     0 |         8 |   0.00 |
-| IDELAYCTRL                  |    0 |     0 |         2 |   0.00 |
-| IBUFGDS                     |    0 |     0 |        96 |   0.00 |
-| PHASER_OUT/PHASER_OUT_PHY   |    0 |     0 |         8 |   0.00 |
-| PHASER_IN/PHASER_IN_PHY     |    0 |     0 |         8 |   0.00 |
-| IDELAYE2/IDELAYE2_FINEDELAY |    0 |     0 |       100 |   0.00 |
-| ILOGIC                      |   28 |    28 |       100 |  28.00 |
-|   IFF_Register              |   28 |    28 |           |        |
-| OLOGIC                      |   22 |    22 |       100 |  22.00 |
-|   OUTFF_Register            |    4 |     4 |           |        |
-|   OUTFF_ODDR_Register       |   18 |    18 |           |        |
-+-----------------------------+------+-------+-----------+--------+
++-----------------------------+------+-------+------------+-----------+--------+
+|          Site Type          | Used | Fixed | Prohibited | Available |  Util% |
++-----------------------------+------+-------+------------+-----------+--------+
+| Bonded IOB                  |   91 |    91 |          0 |       100 |  91.00 |
+|   IOB Master Pads           |   43 |       |            |           |        |
+|   IOB Slave Pads            |   44 |       |            |           |        |
+|   IOB Flip Flops            |   32 |    32 |            |           |        |
+| Bonded IPADs                |    2 |     2 |          0 |         2 | 100.00 |
+| Bonded IOPADs               |  130 |   130 |          0 |       130 | 100.00 |
+| PHY_CONTROL                 |    0 |     0 |          0 |         2 |   0.00 |
+| PHASER_REF                  |    0 |     0 |          0 |         2 |   0.00 |
+| OUT_FIFO                    |    0 |     0 |          0 |         8 |   0.00 |
+| IN_FIFO                     |    0 |     0 |          0 |         8 |   0.00 |
+| IDELAYCTRL                  |    0 |     0 |          0 |         2 |   0.00 |
+| IBUFDS                      |    1 |     1 |          0 |        96 |   1.04 |
+| PHASER_OUT/PHASER_OUT_PHY   |    0 |     0 |          0 |         8 |   0.00 |
+| PHASER_IN/PHASER_IN_PHY     |    0 |     0 |          0 |         8 |   0.00 |
+| IDELAYE2/IDELAYE2_FINEDELAY |    0 |     0 |          0 |       100 |   0.00 |
+| ILOGIC                      |   28 |    28 |          0 |       100 |  28.00 |
+|   IFF_Register              |   28 |    28 |            |           |        |
+| OLOGIC                      |   22 |    22 |          0 |       100 |  22.00 |
+|   OUTFF_Register            |    4 |     4 |            |           |        |
+|   OUTFF_ODDR_Register       |   18 |    18 |            |           |        |
++-----------------------------+------+-------+------------+-----------+--------+
 
 
 6. Clocking
 -----------
 
-+------------+------+-------+-----------+-------+
-|  Site Type | Used | Fixed | Available | Util% |
-+------------+------+-------+-----------+-------+
-| BUFGCTRL   |    6 |     0 |        32 | 18.75 |
-| BUFIO      |    0 |     0 |         8 |  0.00 |
-| MMCME2_ADV |    0 |     0 |         2 |  0.00 |
-| PLLE2_ADV  |    1 |     0 |         2 | 50.00 |
-| BUFMRCE    |    0 |     0 |         4 |  0.00 |
-| BUFHCE     |    0 |     0 |        48 |  0.00 |
-| BUFR       |    0 |     0 |         8 |  0.00 |
-+------------+------+-------+-----------+-------+
++------------+------+-------+------------+-----------+-------+
+|  Site Type | Used | Fixed | Prohibited | Available | Util% |
++------------+------+-------+------------+-----------+-------+
+| BUFGCTRL   |    6 |     0 |          0 |        32 | 18.75 |
+| BUFIO      |    0 |     0 |          0 |         8 |  0.00 |
+| MMCME2_ADV |    0 |     0 |          0 |         2 |  0.00 |
+| PLLE2_ADV  |    1 |     0 |          0 |         2 | 50.00 |
+| BUFMRCE    |    0 |     0 |          0 |         4 |  0.00 |
+| BUFHCE     |    0 |     0 |          0 |        48 |  0.00 |
+| BUFR       |    0 |     0 |          0 |         8 |  0.00 |
++------------+------+-------+------------+-----------+-------+
 
 
 7. Specific Feature
 -------------------
 
-+-------------+------+-------+-----------+--------+
-|  Site Type  | Used | Fixed | Available |  Util% |
-+-------------+------+-------+-----------+--------+
-| BSCANE2     |    0 |     0 |         4 |   0.00 |
-| CAPTUREE2   |    0 |     0 |         1 |   0.00 |
-| DNA_PORT    |    1 |     0 |         1 | 100.00 |
-| EFUSE_USR   |    0 |     0 |         1 |   0.00 |
-| FRAME_ECCE2 |    0 |     0 |         1 |   0.00 |
-| ICAPE2      |    0 |     0 |         2 |   0.00 |
-| STARTUPE2   |    0 |     0 |         1 |   0.00 |
-| XADC        |    1 |     1 |         1 | 100.00 |
-+-------------+------+-------+-----------+--------+
++-------------+------+-------+------------+-----------+--------+
+|  Site Type  | Used | Fixed | Prohibited | Available |  Util% |
++-------------+------+-------+------------+-----------+--------+
+| BSCANE2     |    0 |     0 |          0 |         4 |   0.00 |
+| CAPTUREE2   |    0 |     0 |          0 |         1 |   0.00 |
+| DNA_PORT    |    1 |     0 |          0 |         1 | 100.00 |
+| EFUSE_USR   |    0 |     0 |          0 |         1 |   0.00 |
+| FRAME_ECCE2 |    0 |     0 |          0 |         1 |   0.00 |
+| ICAPE2      |    0 |     0 |          0 |         2 |   0.00 |
+| STARTUPE2   |    0 |     0 |          0 |         1 |   0.00 |
+| XADC        |    1 |     1 |          0 |         1 | 100.00 |
++-------------+------+-------+------------+-----------+--------+
 
 
 8. Primitives
@@ -187,28 +190,26 @@ Table of Contents
 +-----------+-------+----------------------+
 |  Ref Name |  Used |  Functional Category |
 +-----------+-------+----------------------+
-| FDRE      | 13913 |         Flop & Latch |
-| LUT6      |  7533 |                  LUT |
-| LUT5      |  3722 |                  LUT |
-| LUT2      |  3010 |                  LUT |
-| LUT3      |  2382 |                  LUT |
-| LUT4      |  2104 |                  LUT |
-| CARRY4    |  1446 |           CarryLogic |
-| LUT1      |   610 |                  LUT |
-| MUXF7     |   388 |                MuxFx |
-| FDSE      |   354 |         Flop & Latch |
-| MUXF8     |   178 |                MuxFx |
+| FDRE      | 13914 |         Flop & Latch |
+| LUT6      |  7540 |                  LUT |
+| LUT5      |  3181 |                  LUT |
+| LUT2      |  2981 |                  LUT |
+| LUT4      |  2165 |                  LUT |
+| LUT3      |  1700 |                  LUT |
+| CARRY4    |  1458 |           CarryLogic |
+| LUT1      |   717 |                  LUT |
+| MUXF7     |   392 |                MuxFx |
+| FDSE      |   322 |         Flop & Latch |
+| MUXF8     |   164 |                MuxFx |
 | BIBUF     |   130 |                   IO |
-| IBUF      |    58 |                   IO |
-| SRLC32E   |    47 |   Distributed Memory |
+| IBUF      |    54 |                   IO |
 | DSP48E1   |    46 |     Block Arithmetic |
-| RAMD32    |    36 |   Distributed Memory |
 | OBUF      |    35 |                   IO |
 | RAMB36E1  |    34 |         Block Memory |
-| SRL16E    |    24 |   Distributed Memory |
+| SRLC32E   |    33 |   Distributed Memory |
+| SRL16E    |    18 |   Distributed Memory |
 | ODDR      |    18 |                   IO |
-| OBUFT     |    16 |                   IO |
-| RAMS32    |    12 |   Distributed Memory |
+| OBUFT     |    18 |                   IO |
 | BUFG      |     6 |                Clock |
 | XADC      |     1 |               Others |
 | PS7       |     1 | Specialized Resource |

--- a/pyrpl/fpga/out/post_synth_power.rpt
+++ b/pyrpl/fpga/out/post_synth_power.rpt
@@ -1,7 +1,7 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-----------------------------------------------------------------------------------------
-| Tool Version     : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date             : Fri Mar 17 14:07:00 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+-------------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version     : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date             : Wed Feb 19 13:21:30 2025
 | Host             : fontana running 64-bit major release  (build 9200)
 | Command          : report_power -file out/post_synth_power.rpt
 | Design           : red_pitaya_top
@@ -10,7 +10,7 @@ Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
 | Grade            : commercial
 | Process          : typical
 | Characterization : Production
-----------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------------------------------------------
 
 Power Report
 
@@ -29,75 +29,77 @@ Table of Contents
 1. Summary
 ----------
 
-+--------------------------+-------+
-| Total On-Chip Power (W)  | 2.338 |
-| Dynamic (W)              | 2.186 |
-| Device Static (W)        | 0.153 |
-| Effective TJA (C/W)      | 11.5  |
-| Max Ambient (C)          | 58.0  |
-| Junction Temperature (C) | 52.0  |
-| Confidence Level         | Low   |
-| Setting File             | ---   |
-| Simulation Activity File | ---   |
-| Design Nets Matched      | NA    |
-+--------------------------+-------+
++--------------------------+--------------+
+| Total On-Chip Power (W)  | 2.246        |
+| Design Power Budget (W)  | Unspecified* |
+| Power Budget Margin (W)  | NA           |
+| Dynamic (W)              | 2.104        |
+| Device Static (W)        | 0.142        |
+| Effective TJA (C/W)      | 11.5         |
+| Max Ambient (C)          | 59.1         |
+| Junction Temperature (C) | 50.9         |
+| Confidence Level         | Low          |
+| Setting File             | ---          |
+| Simulation Activity File | ---          |
+| Design Nets Matched      | NA           |
++--------------------------+--------------+
+* Specify Design Power Budget using, set_operating_conditions -design_power_budget <value in Watts>
 
 
 1.1 On-Chip Components
 ----------------------
 
-+--------------------------+-----------+----------+-----------+-----------------+
-| On-Chip                  | Power (W) | Used     | Available | Utilization (%) |
-+--------------------------+-----------+----------+-----------+-----------------+
-| Clocks                   |     0.075 |       15 |       --- |             --- |
-| Slice Logic              |     0.143 |    36972 |       --- |             --- |
-|   LUT as Logic           |     0.122 |    17319 |     17600 |           98.40 |
-|   CARRY4                 |     0.016 |     1446 |      4400 |           32.86 |
-|   Register               |     0.005 |    14410 |     35200 |           40.94 |
-|   F7/F8 Muxes            |    <0.001 |      566 |     17600 |            3.22 |
-|   LUT as Shift Register  |    <0.001 |       71 |      6000 |            1.18 |
-|   Others                 |     0.000 |      445 |       --- |             --- |
-|   BUFG                   |     0.000 |        1 |        32 |            3.13 |
-|   LUT as Distributed RAM |     0.000 |       24 |      6000 |            0.40 |
-| Signals                  |     0.141 |    31139 |       --- |             --- |
-| Block RAM                |     0.103 |       34 |        60 |           56.67 |
-| PLL                      |     0.097 |        1 |         2 |           50.00 |
-| DSPs                     |     0.042 |       46 |        80 |           57.50 |
-| I/O                      |     0.288 |       95 |       100 |           95.00 |
-| XADC                     |     0.004 |        1 |       --- |             --- |
-| PS7                      |     1.292 |        1 |       --- |             --- |
-| Static Power             |     0.153 |          |           |                 |
-| Total                    |     2.338 |          |           |                 |
-+--------------------------+-----------+----------+-----------+-----------------+
++-------------------------+-----------+----------+-----------+-----------------+
+| On-Chip                 | Power (W) | Used     | Available | Utilization (%) |
++-------------------------+-----------+----------+-----------+-----------------+
+| Clocks                  |     0.071 |       15 |       --- |             --- |
+| Slice Logic             |     0.125 |    34609 |       --- |             --- |
+|   LUT as Logic          |     0.104 |    16145 |     17600 |           91.73 |
+|   CARRY4                |     0.016 |     1458 |      4400 |           33.14 |
+|   Register              |     0.005 |    13948 |     35200 |           39.63 |
+|   F7/F8 Muxes           |    <0.001 |      556 |     17600 |            3.16 |
+|   LUT as Shift Register |    <0.001 |       51 |      6000 |            0.85 |
+|   Others                |     0.000 |      435 |       --- |             --- |
+|   BUFG                  |     0.000 |        1 |        32 |            3.13 |
+| Signals                 |     0.125 |    29790 |       --- |             --- |
+| Block RAM               |     0.103 |       34 |        60 |           56.67 |
+| PLL                     |     0.097 |        1 |         2 |           50.00 |
+| DSPs                    |     0.042 |       46 |        80 |           57.50 |
+| I/O                     |     0.244 |       91 |       100 |           91.00 |
+| XADC                    |     0.004 |        1 |       --- |             --- |
+| PS7                     |     1.292 |        1 |       --- |             --- |
+| Static Power            |     0.142 |          |           |                 |
+| Total                   |     2.245 |          |           |                 |
++-------------------------+-----------+----------+-----------+-----------------+
 
 
 1.2 Power Supply Summary
 ------------------------
 
-+-----------+-------------+-----------+-------------+------------+
-| Source    | Voltage (V) | Total (A) | Dynamic (A) | Static (A) |
-+-----------+-------------+-----------+-------------+------------+
-| Vccint    |       1.000 |     0.513 |       0.502 |      0.011 |
-| Vccaux    |       1.800 |     0.069 |       0.057 |      0.012 |
-| Vcco33    |       3.300 |     0.085 |       0.084 |      0.001 |
-| Vcco25    |       2.500 |     0.001 |       0.000 |      0.001 |
-| Vcco18    |       1.800 |     0.002 |       0.001 |      0.001 |
-| Vcco15    |       1.500 |     0.001 |       0.000 |      0.001 |
-| Vcco135   |       1.350 |     0.000 |       0.000 |      0.000 |
-| Vcco12    |       1.200 |     0.000 |       0.000 |      0.000 |
-| Vccaux_io |       1.800 |     0.000 |       0.000 |      0.000 |
-| Vccbram   |       1.000 |     0.012 |       0.008 |      0.003 |
-| MGTAVcc   |       1.000 |     0.000 |       0.000 |      0.000 |
-| MGTAVtt   |       1.200 |     0.000 |       0.000 |      0.000 |
-| MGTVccaux |       1.800 |     0.000 |       0.000 |      0.000 |
-| Vccpint   |       1.000 |     0.717 |       0.678 |      0.039 |
-| Vccpaux   |       1.800 |     0.038 |       0.027 |      0.010 |
-| Vccpll    |       1.800 |     0.017 |       0.014 |      0.003 |
-| Vcco_ddr  |       1.500 |     0.356 |       0.354 |      0.002 |
-| Vcco_mio0 |       3.300 |     0.002 |       0.001 |      0.001 |
-| Vcco_mio1 |       2.500 |     0.003 |       0.002 |      0.001 |
-| Vccadc    |       1.800 |     0.022 |       0.002 |      0.020 |
-+-----------+-------------+-----------+-------------+------------+
++-----------+-------------+-----------+-------------+------------+-------------+-------------+------------+
+| Source    | Voltage (V) | Total (A) | Dynamic (A) | Static (A) | Powerup (A) | Budget (A)  | Margin (A) |
++-----------+-------------+-----------+-------------+------------+-------------+-------------+------------+
+| Vccint    |       1.000 |     0.478 |       0.468 |      0.010 |       NA    | Unspecified | NA         |
+| Vccaux    |       1.800 |     0.065 |       0.056 |      0.009 |       NA    | Unspecified | NA         |
+| Vcco33    |       3.300 |     0.071 |       0.070 |      0.001 |       NA    | Unspecified | NA         |
+| Vcco25    |       2.500 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vcco18    |       1.800 |     0.002 |       0.001 |      0.001 |       NA    | Unspecified | NA         |
+| Vcco15    |       1.500 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vcco135   |       1.350 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vcco12    |       1.200 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vccaux_io |       1.800 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vccbram   |       1.000 |     0.012 |       0.008 |      0.003 |       NA    | Unspecified | NA         |
+| MGTAVcc   |       1.000 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| MGTAVtt   |       1.200 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| MGTVccaux |       1.800 |     0.000 |       0.000 |      0.000 |       NA    | Unspecified | NA         |
+| Vccpint   |       1.000 |     0.715 |       0.678 |      0.037 |       NA    | Unspecified | NA         |
+| Vccpaux   |       1.800 |     0.038 |       0.027 |      0.010 |       NA    | Unspecified | NA         |
+| Vccpll    |       1.800 |     0.017 |       0.014 |      0.003 |       NA    | Unspecified | NA         |
+| Vcco_ddr  |       1.500 |     0.356 |       0.354 |      0.002 |       NA    | Unspecified | NA         |
+| Vcco_mio0 |       3.300 |     0.002 |       0.001 |      0.001 |       NA    | Unspecified | NA         |
+| Vcco_mio1 |       2.500 |     0.003 |       0.002 |      0.001 |       NA    | Unspecified | NA         |
+| Vccadc    |       1.800 |     0.022 |       0.002 |      0.020 |       NA    | Unspecified | NA         |
++-----------+-------------+-----------+-------------+------------+-------------+-------------+------------+
 
 
 1.3 Confidence Level
@@ -152,7 +154,6 @@ Table of Contents
 | pll_dac_clk_2x | pll/clk_dac_2x                                                        |             4.0 |
 | pll_pwm_clk    | pll/clk_pwm                                                           |             4.0 |
 | pll_ser_clk    | pll/clk_ser                                                           |             4.0 |
-| rx_clk         | daisy_p_i[1]                                                          |             4.0 |
 +----------------+-----------------------------------------------------------------------+-----------------+
 
 
@@ -162,224 +163,62 @@ Table of Contents
 3.1 By Hierarchy
 ----------------
 
-+----------------------------------------------------------------------------------+-----------+
-| Name                                                                             | Power (W) |
-+----------------------------------------------------------------------------------+-----------+
-| red_pitaya_top                                                                   |     2.185 |
-|   i_ams                                                                          |     0.001 |
-|   i_asg                                                                          |     0.060 |
-|     adv_trig_a                                                                   |     0.002 |
-|     adv_trig_b                                                                   |     0.002 |
-|     ch[0]                                                                        |     0.025 |
-|     ch[1]                                                                        |     0.025 |
-|     prng                                                                         |     0.002 |
-|   i_dsp                                                                          |     0.340 |
-|     dac_saturate[0]                                                              |    <0.001 |
-|     dac_saturate[1]                                                              |    <0.001 |
-|     genblk2[0].i_pid                                                             |     0.024 |
-|       pidfilter                                                                  |     0.013 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|         genblk2[1].lpf                                                           |     0.003 |
-|         genblk2[2].lpf                                                           |     0.003 |
-|         genblk2[3].lpf                                                           |     0.003 |
-|     genblk2[1].i_pid                                                             |     0.024 |
-|       pidfilter                                                                  |     0.013 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|         genblk2[1].lpf                                                           |     0.003 |
-|         genblk2[2].lpf                                                           |     0.003 |
-|         genblk2[3].lpf                                                           |     0.003 |
-|     genblk2[2].i_pid                                                             |     0.024 |
-|       pidfilter                                                                  |     0.013 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|         genblk2[1].lpf                                                           |     0.003 |
-|         genblk2[2].lpf                                                           |     0.003 |
-|         genblk2[3].lpf                                                           |     0.003 |
-|     genblk3[3].i_trigger                                                         |     0.008 |
-|       triggerfilter                                                              |     0.003 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|     genblk4[4].iir                                                               |     0.035 |
-|       iir_inputfilter                                                            |     0.002 |
-|         genblk2[0].lpf                                                           |     0.002 |
-|       p_ay1_module                                                               |     0.003 |
-|       p_ay2_module                                                               |    <0.001 |
-|       p_bx0_module                                                               |    <0.001 |
-|       p_bx1_module                                                               |     0.003 |
-|       s_dat_o_module                                                             |    <0.001 |
-|       s_y0_module                                                                |    <0.001 |
-|     genblk5[5].iq                                                                |     0.062 |
-|       demodulator                                                                |     0.004 |
-|       inputfilter                                                                |     0.003 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|       iq_fgen                                                                    |     0.018 |
-|       iqfilter[0]                                                                |     0.009 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|       iqfilter[1]                                                                |     0.009 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|       modulator                                                                  |     0.010 |
-|         firstproduct_saturation[0]                                               |     0.002 |
-|         firstproduct_saturation[1]                                               |     0.002 |
-|         i0_product_and_sat                                                       |     0.002 |
-|         sumsaturation                                                            |    <0.001 |
-|       pfd_block                                                                  |    <0.001 |
-|     genblk5[6].iq                                                                |     0.062 |
-|       demodulator                                                                |     0.004 |
-|       inputfilter                                                                |     0.003 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|       iq_fgen                                                                    |     0.018 |
-|       iqfilter[0]                                                                |     0.009 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|       iqfilter[1]                                                                |     0.009 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|       modulator                                                                  |     0.010 |
-|         firstproduct_saturation[0]                                               |     0.002 |
-|         firstproduct_saturation[1]                                               |     0.002 |
-|         i0_product_and_sat                                                       |     0.002 |
-|         sumsaturation                                                            |    <0.001 |
-|       pfd_block                                                                  |    <0.001 |
-|     genblk6[7].iq_2_outputs                                                      |     0.082 |
-|       demodulator                                                                |     0.004 |
-|       inputfilter                                                                |     0.003 |
-|         genblk2[0].lpf                                                           |     0.003 |
-|       iq_fgen                                                                    |     0.018 |
-|       iqfilter[0]                                                                |     0.018 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.004 |
-|         genblk2[2].lpf                                                           |     0.004 |
-|         genblk2[3].lpf                                                           |     0.004 |
-|       iqfilter[1]                                                                |     0.018 |
-|         genblk2[0].lpf                                                           |     0.005 |
-|         genblk2[1].lpf                                                           |     0.005 |
-|         genblk2[2].lpf                                                           |     0.005 |
-|         genblk2[3].lpf                                                           |     0.005 |
-|       modulator                                                                  |     0.012 |
-|         firstproduct_saturation[0]                                               |     0.002 |
-|         firstproduct_saturation[1]                                               |     0.002 |
-|         i0_product_and_sat                                                       |     0.002 |
-|         q0_product_and_sat                                                       |     0.002 |
-|         sumsaturation                                                            |    <0.001 |
-|       pfd_block                                                                  |    <0.001 |
-|   i_hk                                                                           |     0.001 |
-|   i_iobufn[0]                                                                    |    <0.001 |
-|   i_iobufn[1]                                                                    |    <0.001 |
-|   i_iobufn[2]                                                                    |    <0.001 |
-|   i_iobufn[3]                                                                    |    <0.001 |
-|   i_iobufn[4]                                                                    |    <0.001 |
-|   i_iobufn[5]                                                                    |    <0.001 |
-|   i_iobufn[6]                                                                    |    <0.001 |
-|   i_iobufn[7]                                                                    |    <0.001 |
-|   i_iobufp[0]                                                                    |    <0.001 |
-|   i_iobufp[1]                                                                    |    <0.001 |
-|   i_iobufp[2]                                                                    |    <0.001 |
-|   i_iobufp[3]                                                                    |    <0.001 |
-|   i_iobufp[4]                                                                    |    <0.001 |
-|   i_iobufp[5]                                                                    |    <0.001 |
-|   i_iobufp[6]                                                                    |    <0.001 |
-|   i_iobufp[7]                                                                    |    <0.001 |
-|   i_ps                                                                           |     1.326 |
-|     axi_master[0]                                                                |     0.001 |
-|       axi_awfifo_reg_0_15_30_35                                                  |    <0.001 |
-|       axi_awfifo_reg_0_15_36_36                                                  |    <0.001 |
-|       axi_wfifo_reg_0_15_60_65                                                   |    <0.001 |
-|     axi_master[1]                                                                |     0.001 |
-|       axi_awfifo_reg_0_15_30_35                                                  |    <0.001 |
-|       axi_awfifo_reg_0_15_36_36                                                  |    <0.001 |
-|       axi_wfifo_reg_0_15_60_65                                                   |    <0.001 |
-|     axi_slave_gp0                                                                |     0.001 |
-|     system_i                                                                     |     1.321 |
-|       system_i                                                                   |     1.321 |
-|         axi_protocol_converter_0                                                 |     0.017 |
-|           inst                                                                   |     0.017 |
-|             gen_axilite.gen_b2s_conv.axilite_b2s                                 |     0.017 |
-|               MI_REG                                                             |     0.000 |
-|                 ar_pipe                                                          |     0.000 |
-|                 aw_pipe                                                          |     0.000 |
-|                 axi_infrastructure_v1_1_0_axi2vector_0                           |     0.000 |
-|                 axi_infrastructure_v1_1_0_vector2axi_0                           |     0.000 |
-|                 b_pipe                                                           |     0.000 |
-|                 r_pipe                                                           |     0.000 |
-|                 w_pipe                                                           |     0.000 |
-|               RD.ar_channel_0                                                    |     0.003 |
-|                 ar_cmd_fsm_0                                                     |    <0.001 |
-|                 cmd_translator_0                                                 |     0.003 |
-|                   incr_cmd_0                                                     |    <0.001 |
-|                   wrap_cmd_0                                                     |     0.001 |
-|               RD.r_channel_0                                                     |     0.003 |
-|                 rd_data_fifo_0                                                   |     0.001 |
-|                 transaction_fifo_0                                               |    <0.001 |
-|               SI_REG                                                             |     0.006 |
-|                 ar_pipe                                                          |     0.002 |
-|                 aw_pipe                                                          |     0.002 |
-|                 axi_infrastructure_v1_1_0_axi2vector_0                           |     0.000 |
-|                 axi_infrastructure_v1_1_0_vector2axi_0                           |     0.000 |
-|                 b_pipe                                                           |    <0.001 |
-|                 r_pipe                                                           |     0.002 |
-|                 w_pipe                                                           |     0.000 |
-|               WR.aw_channel_0                                                    |     0.004 |
-|                 aw_cmd_fsm_0                                                     |    <0.001 |
-|                 cmd_translator_0                                                 |     0.003 |
-|                   incr_cmd_0                                                     |     0.001 |
-|                   wrap_cmd_0                                                     |     0.002 |
-|               WR.b_channel_0                                                     |     0.001 |
-|                 bid_fifo_0                                                       |    <0.001 |
-|                 bresp_fifo_0                                                     |    <0.001 |
-|         proc_sys_reset                                                           |    <0.001 |
-|           U0                                                                     |    <0.001 |
-|             EXT_LPF                                                              |    <0.001 |
-|               ACTIVE_LOW_AUX.ACT_LO_AUX                                          |    <0.001 |
-|               ACTIVE_LOW_EXT.ACT_LO_EXT                                          |    <0.001 |
-|             SEQ                                                                  |    <0.001 |
-|               SEQ_COUNTER                                                        |    <0.001 |
-|         processing_system7                                                       |     1.293 |
-|           inst                                                                   |     1.293 |
-|             xlnx_axi_wrshim_unwrap_inst_gp0                                      |    <0.001 |
-|             xlnx_axi_wrshim_unwrap_inst_gp1                                      |    <0.001 |
-|         xadc                                                                     |     0.010 |
-|           inst                                                                   |     0.010 |
-|             AXI_LITE_IPIF_I                                                      |     0.002 |
-|               I_SLAVE_ATTACHMENT                                                 |     0.002 |
-|                 I_DECODER                                                        |    <0.001 |
-|                   MEM_DECODE_GEN[0].GEN_FOR_MULTI_CS.MEM_SELECT_I                |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[0].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[1].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[2].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[3].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[4].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[5].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[6].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[0].PER_CE_GEN[7].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].GEN_FOR_MULTI_CS.MEM_SELECT_I                |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[0].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[10].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[11].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[12].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[13].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[14].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[15].MULTIPLE_CES_THIS_CS_GEN.CE_I |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[1].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[2].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[3].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[4].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[5].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[6].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[7].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[8].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[1].PER_CE_GEN[9].MULTIPLE_CES_THIS_CS_GEN.CE_I  |    <0.001 |
-|                   MEM_DECODE_GEN[2].GEN_FOR_MULTI_CS.MEM_SELECT_I                |    <0.001 |
-|             AXI_XADC_CORE_I                                                      |     0.005 |
-|             INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I                                 |     0.001 |
-|             SOFT_RESET_I                                                         |    <0.001 |
-|         xlconstant                                                               |     0.000 |
-|           inst                                                                   |     0.000 |
-|   i_scope                                                                        |     0.054 |
-|   pll                                                                            |     0.097 |
-|   pwm[0]                                                                         |     0.002 |
-|   pwm[1]                                                                         |     0.002 |
-|   pwm[2]                                                                         |     0.002 |
-|   pwm[3]                                                                         |     0.002 |
-+----------------------------------------------------------------------------------+-----------+
++-----------------------------+-----------+
+| Name                        | Power (W) |
++-----------------------------+-----------+
+| red_pitaya_top              |     2.104 |
+|   i_ams                     |     0.001 |
+|   i_asg                     |     0.060 |
+|     adv_trig_a              |     0.001 |
+|     adv_trig_b              |     0.001 |
+|     ch[0]                   |     0.025 |
+|     ch[1]                   |     0.025 |
+|     prng                    |     0.002 |
+|   i_dsp                     |     0.313 |
+|     genblk2[0].i_pid        |     0.022 |
+|       pidfilter             |     0.011 |
+|     genblk2[1].i_pid        |     0.022 |
+|       pidfilter             |     0.011 |
+|     genblk2[2].i_pid        |     0.022 |
+|       pidfilter             |     0.011 |
+|     genblk3[3].i_trigger    |     0.006 |
+|       triggerfilter         |     0.003 |
+|     genblk4[4].iir          |     0.031 |
+|       iir_inputfilter       |     0.002 |
+|       p_ay1_module          |     0.003 |
+|       p_bx1_module          |     0.003 |
+|     genblk5[5].iq           |     0.058 |
+|       demodulator           |     0.004 |
+|       inputfilter           |     0.003 |
+|       iq_fgen               |     0.018 |
+|       iqfilter[0]           |     0.008 |
+|       iqfilter[1]           |     0.008 |
+|       modulator             |     0.010 |
+|     genblk5[6].iq           |     0.058 |
+|       demodulator           |     0.004 |
+|       inputfilter           |     0.003 |
+|       iq_fgen               |     0.018 |
+|       iqfilter[0]           |     0.008 |
+|       iqfilter[1]           |     0.008 |
+|       modulator             |     0.010 |
+|     genblk6[7].iq_2_outputs |     0.077 |
+|       demodulator           |     0.004 |
+|       inputfilter           |     0.003 |
+|       iq_fgen               |     0.018 |
+|       iqfilter[0]           |     0.016 |
+|       iqfilter[1]           |     0.016 |
+|       modulator             |     0.012 |
+|   i_hk                      |     0.001 |
+|   i_ps                      |     1.318 |
+|     axi_slave_gp0           |     0.002 |
+|     system_i                |     1.314 |
+|       system_i              |     1.314 |
+|   i_scope                   |     0.051 |
+|   pll                       |     0.097 |
+|   pwm[0]                    |     0.002 |
+|   pwm[1]                    |     0.002 |
+|   pwm[2]                    |     0.002 |
+|   pwm[3]                    |     0.002 |
++-----------------------------+-----------+
 
 

--- a/pyrpl/fpga/out/post_synth_timing_summary.rpt
+++ b/pyrpl/fpga/out/post_synth_timing_summary.rpt
@@ -1,13 +1,14 @@
-Copyright 1986-2015 Xilinx, Inc. All Rights Reserved.
-------------------------------------------------------------------------------------
-| Tool Version : Vivado v.2015.4 (win64) Build 1412921 Wed Nov 18 09:43:45 MST 2015
-| Date         : Fri Mar 17 14:06:53 2023
+Copyright 1986-2022 Xilinx, Inc. All Rights Reserved. Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
+---------------------------------------------------------------------------------------------------------------------------------------------
+| Tool Version : Vivado v.2024.2 (win64) Build 5239630 Fri Nov 08 22:35:27 MST 2024
+| Date         : Wed Feb 19 13:21:21 2025
 | Host         : fontana running 64-bit major release  (build 9200)
 | Command      : report_timing_summary -file out/post_synth_timing_summary.rpt
 | Design       : red_pitaya_top
 | Device       : 7z010-clg400
-| Speed File   : -1  PRODUCTION 1.11 2014-09-11
-------------------------------------------------------------------------------------
+| Speed File   : -1  PRODUCTION 1.12 2019-11-22
+| Design State : Synthesized
+---------------------------------------------------------------------------------------------------------------------------------------------
 
 Timing Summary Report
 
@@ -23,7 +24,10 @@ Timing Summary Report
   Enable Preset / Clear Arcs                 :  No
   Disable Flight Delays                      :  No
   Ignore I/O Paths                           :  No
-  Timing Early Launch at Borrowing Latches   :  false
+  Timing Early Launch at Borrowing Latches   :  No
+  Borrow Time for Max Delay Exceptions       :  Yes
+  Merge Timing Exceptions                    :  Yes
+  Inter-SLR Compensation                     :  Conservative
 
   Corner  Analyze    Analyze    
   Name    Max Paths  Min Paths  
@@ -32,55 +36,63 @@ Timing Summary Report
   Fast    Yes        Yes        
 
 
+------------------------------------------------------------------------------------------------
+| Report Methodology
+| ------------------
+------------------------------------------------------------------------------------------------
+
+No report available as report_methodology has not been run prior. Run report_methodology on the current design for the summary of methodology violations.
+
+
 
 check_timing report
 
 Table of Contents
 -----------------
-1. checking no_clock
-2. checking constant_clock
-3. checking pulse_width_clock
-4. checking unconstrained_internal_endpoints
-5. checking no_input_delay
-6. checking no_output_delay
-7. checking multiple_clock
-8. checking generated_clocks
-9. checking loops
-10. checking partial_input_delay
-11. checking partial_output_delay
-12. checking latch_loops
+1. checking no_clock (1)
+2. checking constant_clock (0)
+3. checking pulse_width_clock (0)
+4. checking unconstrained_internal_endpoints (2)
+5. checking no_input_delay (16)
+6. checking no_output_delay (46)
+7. checking multiple_clock (0)
+8. checking generated_clocks (0)
+9. checking loops (0)
+10. checking partial_input_delay (0)
+11. checking partial_output_delay (0)
+12. checking latch_loops (0)
 
-1. checking no_clock
---------------------
- There is 1 register/latch pin with no clock driven by root clock pin: i_hk/dna_clk_reg/C (HIGH)
+1. checking no_clock (1)
+------------------------
+ There is 1 register/latch pin with no clock driven by root clock pin: i_hk/dna_clk_reg/Q (HIGH)
 
 
-2. checking constant_clock
---------------------------
+2. checking constant_clock (0)
+------------------------------
  There are 0 register/latch pins with constant_clock.
 
 
-3. checking pulse_width_clock
------------------------------
+3. checking pulse_width_clock (0)
+---------------------------------
  There are 0 register/latch pins which need pulse_width check
 
 
-4. checking unconstrained_internal_endpoints
---------------------------------------------
+4. checking unconstrained_internal_endpoints (2)
+------------------------------------------------
  There are 2 pins that are not constrained for maximum delay. (HIGH)
 
- There are 10 pins that are not constrained for maximum delay due to constant clock. (MEDIUM)
+ There are 0 pins that are not constrained for maximum delay due to constant clock.
 
 
-5. checking no_input_delay
---------------------------
+5. checking no_input_delay (16)
+-------------------------------
  There are 16 input ports with no input delay specified. (HIGH)
 
  There are 0 input ports with no input delay but user has a false path constraint.
 
 
-6. checking no_output_delay
----------------------------
+6. checking no_output_delay (46)
+--------------------------------
  There are 46 ports with no output delay specified. (HIGH)
 
  There are 0 ports with no output delay but user has a false path constraint
@@ -88,33 +100,33 @@ Table of Contents
  There are 0 ports with no output delay but with a timing clock defined on it or propagating through it
 
 
-7. checking multiple_clock
---------------------------
+7. checking multiple_clock (0)
+------------------------------
  There are 0 register/latch pins with multiple clocks.
 
 
-8. checking generated_clocks
-----------------------------
+8. checking generated_clocks (0)
+--------------------------------
  There are 0 generated clocks that are not connected to a clock source.
 
 
-9. checking loops
------------------
+9. checking loops (0)
+---------------------
  There are 0 combinational loops in the design.
 
 
-10. checking partial_input_delay
---------------------------------
+10. checking partial_input_delay (0)
+------------------------------------
  There are 0 input ports with partial input delay specified.
 
 
-11. checking partial_output_delay
----------------------------------
+11. checking partial_output_delay (0)
+-------------------------------------
  There are 0 ports with partial output delay specified.
 
 
-12. checking latch_loops
-------------------------
+12. checking latch_loops (0)
+----------------------------
  There are 0 combinational latch loops in the design through latch input
 
 
@@ -126,7 +138,7 @@ Table of Contents
 
     WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints     WPWS(ns)     TPWS(ns)  TPWS Failing Endpoints  TPWS Total Endpoints  
     -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
-     -5.251    -1124.981                    447                36308       -0.089       -7.124                    107                36308        1.000        0.000                       0                 14643  
+     -5.525    -1152.848                    435                34947       -0.089       -7.139                    107                34947        1.000        0.000                       0                 14155  
 
 
 Timing constraints are not met.
@@ -163,16 +175,16 @@ Clock                 WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total End
 -----                 -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------     --------     --------  ----------------------  --------------------  
 adc_clk                                                                                                                                                             2.000        0.000                       0                     1  
   clk_fb                                                                                                                                                            6.751        0.000                       0                     2  
-  pll_adc_clk          -5.251    -1115.572                    423                33779        0.074        0.000                      0                33779        2.750        0.000                       0                 13377  
-  pll_dac_clk_1x        1.521        0.000                      0                   45       -0.089       -1.333                     15                   45        3.500        0.000                       0                    47  
+  pll_adc_clk          -5.525    -1150.043                    423                32857        0.067        0.000                      0                32857        3.500        0.000                       0                 13122  
+  pll_dac_clk_1x        1.626        0.000                      0                   45       -0.089       -1.334                     15                   45        3.500        0.000                       0                    47  
   pll_dac_clk_2p                                                                                                                                                    1.845        0.000                       0                     3  
   pll_dac_clk_2x                                                                                                                                                    1.845        0.000                       0                     3  
-  pll_pwm_clk          -0.466       -1.862                      4                  412        0.126        0.000                      0                  412        1.500        0.000                       0                   217  
+  pll_pwm_clk          -0.363       -1.454                      4                  412        0.126        0.000                      0                  412        1.500        0.000                       0                   217  
   pll_ser_clk                                                                                                                                                       1.845        0.000                       0                     2  
 clk_fpga_0                                                                                                                                                          5.845        0.000                       0                     2  
 clk_fpga_1                                                                                                                                                          1.845        0.000                       0                     2  
 clk_fpga_2                                                                                                                                                         17.845        0.000                       0                     2  
-clk_fpga_3             -0.672       -7.546                     20                 1984        0.007        0.000                      0                 1984        1.000        0.000                       0                   985  
+clk_fpga_3             -0.169       -1.351                      8                 1545        0.045        0.000                      0                 1545        1.000        0.000                       0                   752  
 
 
 ------------------------------------------------------------------------------------------------
@@ -182,9 +194,9 @@ clk_fpga_3             -0.672       -7.546                     20               
 
 From Clock      To Clock            WNS(ns)      TNS(ns)  TNS Failing Endpoints  TNS Total Endpoints      WHS(ns)      THS(ns)  THS Failing Endpoints  THS Total Endpoints  
 ----------      --------            -------      -------  ---------------------  -------------------      -------      -------  ---------------------  -------------------  
-adc_clk         pll_adc_clk           5.085        0.000                      0                   28        0.490        0.000                      0                   28  
-pll_adc_clk     pll_dac_clk_1x        5.303        0.000                      0                   28       -0.026       -0.053                      2                   28  
-pll_adc_clk     pll_pwm_clk           2.077        0.000                      0                   94       -0.071       -5.739                     90                   94  
+adc_clk         pll_adc_clk           4.849        0.000                      0                   28        1.266        0.000                      0                   28  
+pll_adc_clk     pll_dac_clk_1x        5.303        0.000                      0                   28       -0.027       -0.054                      2                   28  
+pll_adc_clk     pll_pwm_clk           2.077        0.000                      0                   94       -0.071       -5.752                     90                   94  
 
 
 ------------------------------------------------------------------------------------------------
@@ -254,15 +266,15 @@ Max Period  n/a     PLLE2_ADV/CLKFBIN   n/a            52.633        8.000      
 From Clock:  pll_adc_clk
   To Clock:  pll_adc_clk
 
-Setup :          423  Failing Endpoints,  Worst Slack       -5.251ns,  Total Violation    -1115.572ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.074ns,  Total Violation        0.000ns
-PW    :            0  Failing Endpoints,  Worst Slack        2.750ns,  Total Violation        0.000ns
+Setup :          423  Failing Endpoints,  Worst Slack       -5.525ns,  Total Violation    -1150.043ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.067ns,  Total Violation        0.000ns
+PW    :            0  Failing Endpoints,  Worst Slack        3.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -5.251ns  (required time - arrival time)
+Slack (VIOLATED) :        -5.525ns  (required time - arrival time)
   Source:                 i_dsp/genblk4[4].iir/y1a_reg[16]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            i_dsp/genblk4[4].iir/overflow_reg[0]/D
@@ -270,8 +282,8 @@ Slack (VIOLATED) :        -5.251ns  (required time - arrival time)
   Path Group:             pll_adc_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            8.000ns  (pll_adc_clk rise@8.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        13.066ns  (logic 9.717ns (74.370%)  route 3.349ns (25.630%))
-  Logic Levels:           18  (CARRY4=12 DSP48E1=2 LUT1=1 LUT2=2 LUT4=1)
+  Data Path Delay:        13.340ns  (logic 9.696ns (72.681%)  route 3.644ns (27.319%))
+  Logic Levels:           17  (CARRY4=12 DSP48E1=2 LUT2=2 LUT4=1)
   Clock Path Skew:        -0.145ns (DCD - SCD + CPR)
     Destination Clock Delay (DCD):    2.969ns = ( 10.969 - 8.000 ) 
     Source Clock Delay      (SCD):    3.357ns
@@ -293,61 +305,59 @@ Slack (VIOLATED) :        -5.251ns  (required time - arrival time)
                                                       0.089     1.656 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.800     2.456    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.101     2.557 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.800     3.357    i_dsp/genblk4[4].iir/clk_i
+                         net (fo=13129, unplaced)     0.800     3.357    i_dsp/genblk4[4].iir/clk_i
                          FDRE                                         r  i_dsp/genblk4[4].iir/y1a_reg[16]/C
   -------------------------------------------------------------------    -------------------
                          FDRE (Prop_fdre_C_Q)         0.456     3.813 r  i_dsp/genblk4[4].iir/y1a_reg[16]/Q
-                         net (fo=1, unplaced)         0.800     4.613    i_dsp/genblk4[4].iir/p_ay1_module/factor1_i[16]
+                         net (fo=1, unplaced)         0.800     4.612    i_dsp/genblk4[4].iir/p_ay1_module/factor1_i[16]
                          DSP48E1 (Prop_dsp48e1_A[16]_PCOUT[47])
-                                                      4.211     8.824 r  i_dsp/genblk4[4].iir/p_ay1_module/product0__1/PCOUT[47]
-                         net (fo=1, unplaced)         0.000     8.824    i_dsp/genblk4[4].iir/p_ay1_module/product0__1_n_106
+                                                      4.211     8.823 r  i_dsp/genblk4[4].iir/p_ay1_module/product0__1/PCOUT[47]
+                         net (fo=1, unplaced)         0.000     8.823    i_dsp/genblk4[4].iir/p_ay1_module/product0__1_n_106
                          DSP48E1 (Prop_dsp48e1_PCIN[47]_P[0])
-                                                      1.518    10.342 r  i_dsp/genblk4[4].iir/p_ay1_module/product0__2/P[0]
-                         net (fo=2, unplaced)         0.800    11.142    i_dsp/genblk4[4].iir/p_ay1_module/product0__2_n_105
-                         LUT2 (Prop_lut2_I0_O)        0.124    11.266 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_24/O
-                         net (fo=1, unplaced)         0.000    11.266    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_24_n_0
+                                                      1.518    10.341 r  i_dsp/genblk4[4].iir/p_ay1_module/product0__2/P[0]
+                         net (fo=2, unplaced)         0.800    11.141    i_dsp/genblk4[4].iir/p_ay1_module/product0__2_n_105
+                         LUT2 (Prop_lut2_I0_O)        0.124    11.265 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_16/O
+                         net (fo=1, unplaced)         0.000    11.265    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_16_n_0
                          CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.550    11.816 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_17/CO[3]
-                         net (fo=1, unplaced)         0.000    11.816    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_17_n_0
+                                                      0.533    11.798 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_9/CO[3]
+                         net (fo=1, unplaced)         0.000    11.798    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_9_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    11.930 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_12/CO[3]
-                         net (fo=1, unplaced)         0.000    11.930    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_12_n_0
+                                                      0.117    11.915 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_4/CO[3]
+                         net (fo=1, unplaced)         0.000    11.915    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_4_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.044 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_7/CO[3]
-                         net (fo=1, unplaced)         0.000    12.044    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_7_n_0
+                                                      0.117    12.032 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_3/CO[3]
+                         net (fo=1, unplaced)         0.000    12.032    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_3_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.158 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_2/CO[3]
-                         net (fo=1, unplaced)         0.000    12.158    i_dsp/genblk4[4].iir/p_ay1_module/product_o[1]_INST_0_i_2_n_0
+                                                      0.117    12.149 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[5]_INST_0_i_2/CO[3]
+                         net (fo=1, unplaced)         0.000    12.149    i_dsp/genblk4[4].iir/p_ay1_module/product_o[5]_INST_0_i_2_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.272 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[9]_INST_0_i_6/CO[3]
-                         net (fo=1, unplaced)         0.000    12.272    i_dsp/genblk4[4].iir/p_ay1_module/product_o[9]_INST_0_i_6_n_0
+                                                      0.117    12.266 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[9]_INST_0_i_2/CO[3]
+                         net (fo=1, unplaced)         0.000    12.266    i_dsp/genblk4[4].iir/p_ay1_module/product_o[9]_INST_0_i_2_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.386 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[13]_INST_0_i_6/CO[3]
-                         net (fo=1, unplaced)         0.000    12.386    i_dsp/genblk4[4].iir/p_ay1_module/product_o[13]_INST_0_i_6_n_0
+                                                      0.117    12.383 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[13]_INST_0_i_2/CO[3]
+                         net (fo=1, unplaced)         0.000    12.383    i_dsp/genblk4[4].iir/p_ay1_module/product_o[13]_INST_0_i_2_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.500 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[17]_INST_0_i_6/CO[3]
-                         net (fo=1, unplaced)         0.000    12.500    i_dsp/genblk4[4].iir/p_ay1_module/product_o[17]_INST_0_i_6_n_0
+                                                      0.117    12.500 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[17]_INST_0_i_2/CO[3]
+                         net (fo=1, unplaced)         0.000    12.500    i_dsp/genblk4[4].iir/p_ay1_module/product_o[17]_INST_0_i_2_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.614 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[21]_INST_0_i_6/CO[3]
-                         net (fo=1, unplaced)         0.000    12.614    i_dsp/genblk4[4].iir/p_ay1_module/product_o[21]_INST_0_i_6_n_0
+                                                      0.117    12.617 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[21]_INST_0_i_2/CO[3]
+                         net (fo=1, unplaced)         0.000    12.617    i_dsp/genblk4[4].iir/p_ay1_module/product_o[21]_INST_0_i_2_n_0
                          CARRY4 (Prop_carry4_CI_CO[3])
-                                                      0.114    12.728 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[25]_INST_0_i_6/CO[3]
-                         net (fo=1, unplaced)         0.000    12.728    i_dsp/genblk4[4].iir/p_ay1_module/product_o[25]_INST_0_i_6_n_0
+                                                      0.117    12.734 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[25]_INST_0_i_2/CO[3]
+                         net (fo=1, unplaced)         0.000    12.734    i_dsp/genblk4[4].iir/p_ay1_module/product_o[25]_INST_0_i_2_n_0
                          CARRY4 (Prop_carry4_CI_O[3])
-                                                      0.329    13.057 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_6/O[3]
-                         net (fo=1, unplaced)         0.618    13.675    i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_6_n_4
-                         LUT1 (Prop_lut1_I0_O)        0.307    13.982 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_5/O
-                         net (fo=1, unplaced)         0.000    13.982    i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_5_n_0
+                                                      0.331    13.065 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_2/O[3]
+                         net (fo=1, unplaced)         0.808    13.873    i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_2_n_4
                          CARRY4 (Prop_carry4_S[0]_CO[3])
-                                                      0.532    14.514 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_1/CO[3]
-                         net (fo=1, unplaced)         0.000    14.514    i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_1_n_0
+                                                      0.820    14.693 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_1/CO[3]
+                         net (fo=1, unplaced)         0.000    14.693    i_dsp/genblk4[4].iir/p_ay1_module/product_o[29]_INST_0_i_1_n_0
                          CARRY4 (Prop_carry4_CI_O[1])
-                                                      0.348    14.862 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[30]_INST_0_i_1/O[1]
-                         net (fo=32, unplaced)        0.682    15.544    i_dsp/genblk4[4].iir/p_ay1_module/p_0_in[0]
-                         LUT4 (Prop_lut4_I2_O)        0.306    15.850 r  i_dsp/genblk4[4].iir/p_ay1_module/overflow_INST_0/O
-                         net (fo=1, unplaced)         0.449    16.299    i_dsp/genblk4[4].iir/overflow_i[0]
-                         LUT2 (Prop_lut2_I0_O)        0.124    16.423 r  i_dsp/genblk4[4].iir/overflow[0]_i_1/O
-                         net (fo=1, unplaced)         0.000    16.423    i_dsp/genblk4[4].iir/overflow[0]_i_1_n_0
+                                                      0.337    15.030 r  i_dsp/genblk4[4].iir/p_ay1_module/product_o[30]_INST_0_i_1/O[1]
+                         net (fo=32, unplaced)        0.788    15.818    i_dsp/genblk4[4].iir/p_ay1_module/p_0_in[0]
+                         LUT4 (Prop_lut4_I1_O)        0.306    16.124 r  i_dsp/genblk4[4].iir/p_ay1_module/overflow_INST_0/O
+                         net (fo=1, unplaced)         0.449    16.573    i_dsp/genblk4[4].iir/overflow_i[0]
+                         LUT2 (Prop_lut2_I1_O)        0.124    16.697 r  i_dsp/genblk4[4].iir/overflow[0]_i_1/O
+                         net (fo=1, unplaced)         0.000    16.697    i_dsp/genblk4[4].iir/overflow[0]_i_1_n_0
                          FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[0]/D
   -------------------------------------------------------------------    -------------------
 
@@ -361,16 +371,16 @@ Slack (VIOLATED) :        -5.251ns  (required time - arrival time)
                                                       0.084     9.463 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.760    10.223    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.091    10.314 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.655    10.969    i_dsp/genblk4[4].iir/clk_i
+                         net (fo=13129, unplaced)     0.655    10.969    i_dsp/genblk4[4].iir/clk_i
                          FDRE                                         r  i_dsp/genblk4[4].iir/overflow_reg[0]/C
                          clock pessimism              0.243    11.212    
                          clock uncertainty           -0.069    11.143    
                          FDRE (Setup_fdre_C_D)        0.029    11.172    i_dsp/genblk4[4].iir/overflow_reg[0]
   -------------------------------------------------------------------
                          required time                         11.172    
-                         arrival time                         -16.423    
+                         arrival time                         -16.697    
   -------------------------------------------------------------------
-                         slack                                 -5.251    
+                         slack                                 -5.525    
 
 
 
@@ -378,19 +388,19 @@ Slack (VIOLATED) :        -5.251ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.074ns  (arrival time - required time)
-  Source:                 i_asg/ch[0]/ext_trig_debn_reg[17]/C
+Slack (MET) :             0.067ns  (arrival time - required time)
+  Source:                 i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[10]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
-  Destination:            i_asg/ch[0]/ext_trig_debn_reg[18]/D
+  Destination:            i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[11]/D
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Path Group:             pll_adc_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_adc_clk rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.324ns  (logic 0.235ns (72.544%)  route 0.089ns (27.456%))
+  Data Path Delay:        0.325ns  (logic 0.239ns (73.636%)  route 0.086ns (26.364%))
   Logic Levels:           1  (CARRY4=1)
   Clock Path Skew:        0.145ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    1.485ns
-    Source Clock Delay      (SCD):    1.140ns
+    Source Clock Delay      (SCD):    1.139ns
     Clock Pessimism Removal (CPR):    0.200ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
@@ -405,15 +415,15 @@ Slack (MET) :             0.074ns  (arrival time - required time)
                                                       0.051     0.566 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.337     0.904    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.026     0.930 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.210     1.140    i_asg/ch[0]/dac_clk_i
-                         FDRE                                         r  i_asg/ch[0]/ext_trig_debn_reg[17]/C
+                         net (fo=13129, unplaced)     0.210     1.139    i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/clk_i
+                         FDRE                                         r  i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[10]/C
   -------------------------------------------------------------------    -------------------
-                         FDRE (Prop_fdre_C_Q)         0.141     1.281 r  i_asg/ch[0]/ext_trig_debn_reg[17]/Q
-                         net (fo=3, unplaced)         0.089     1.369    i_asg/ch[0]/ext_trig_debn_reg_n_0_[17]
-                         CARRY4 (Prop_carry4_DI[0]_O[1])
-                                                      0.094     1.463 r  i_asg/ch[0]/ext_trig_debn_reg[19]_i_3/O[1]
-                         net (fo=1, unplaced)         0.000     1.463    i_asg/ch[0]/ext_trig_debn_reg[19]_i_3_n_6
-                         FDRE                                         r  i_asg/ch[0]/ext_trig_debn_reg[18]/D
+                         FDRE (Prop_fdre_C_Q)         0.147     1.286 r  i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[10]/Q
+                         net (fo=2, unplaced)         0.086     1.372    i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg_n_0_[10]
+                         CARRY4 (Prop_carry4_DI[2]_O[3])
+                                                      0.092     1.464 r  i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[8]_i_1/O[3]
+                         net (fo=1, unplaced)         0.000     1.464    i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[8]_i_1_n_4
+                         FDRE                                         r  i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[11]/D
   -------------------------------------------------------------------    -------------------
 
                          (clock pll_adc_clk rise edge)
@@ -426,15 +436,15 @@ Slack (MET) :             0.074ns  (arrival time - required time)
                                                       0.054     0.746 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.355     1.101    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.029     1.130 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.355     1.485    i_asg/ch[0]/dac_clk_i
-                         FDRE                                         r  i_asg/ch[0]/ext_trig_debn_reg[18]/C
-                         clock pessimism             -0.200     1.285    
-                         FDRE (Hold_fdre_C_D)         0.105     1.390    i_asg/ch[0]/ext_trig_debn_reg[18]
+                         net (fo=13129, unplaced)     0.355     1.485    i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/clk_i
+                         FDRE                                         r  i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[11]/C
+                         clock pessimism             -0.200     1.284    
+                         FDRE (Hold_fdre_C_D)         0.113     1.397    i_dsp/genblk2[0].i_pid/pidfilter/genblk2[0].lpf/y_reg[11]
   -------------------------------------------------------------------
-                         required time                         -1.390    
-                         arrival time                           1.463    
+                         required time                         -1.397    
+                         arrival time                           1.464    
   -------------------------------------------------------------------
-                         slack                                  0.074    
+                         slack                                  0.067    
 
 
 
@@ -448,10 +458,10 @@ Period(ns):         8.000
 Sources:            { pll/pll/CLKOUT0 }
 
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location  Pin
-Min Period        n/a     DSP48E1/CLK        n/a            3.884         8.000       4.116                i_dsp/genblk2[0].i_pid/kp_mult0/CLK
+Min Period        n/a     DSP48E1/CLK        n/a            3.884         8.000       4.116                i_dsp/genblk2[0].i_pid/ki_mult_reg/CLK
 Max Period        n/a     PLLE2_ADV/CLKOUT0  n/a            160.000       8.000       152.000              pll/pll/CLKOUT0
-Low Pulse Width   Fast    RAMD32/CLK         n/a            1.250         4.000       2.750                i_ps/axi_master[0]/axi_awfifo_reg_0_15_30_35/RAMA/CLK
-High Pulse Width  Slow    RAMD32/CLK         n/a            1.250         4.000       2.750                i_ps/axi_master[0]/axi_awfifo_reg_0_15_30_35/RAMA/CLK
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500                adc_rstn_reg/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500                adc_rstn_reg/C
 
 
 
@@ -459,15 +469,15 @@ High Pulse Width  Slow    RAMD32/CLK         n/a            1.250         4.000 
 From Clock:  pll_dac_clk_1x
   To Clock:  pll_dac_clk_1x
 
-Setup :            0  Failing Endpoints,  Worst Slack        1.521ns,  Total Violation        0.000ns
-Hold  :           15  Failing Endpoints,  Worst Slack       -0.089ns,  Total Violation       -1.333ns
+Setup :            0  Failing Endpoints,  Worst Slack        1.626ns,  Total Violation        0.000ns
+Hold  :           15  Failing Endpoints,  Worst Slack       -0.089ns,  Total Violation       -1.334ns
 PW    :            0  Failing Endpoints,  Worst Slack        3.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             1.521ns  (required time - arrival time)
+Slack (MET) :             1.626ns  (required time - arrival time)
   Source:                 dac_dat_a_reg[0]/C
                             (rising edge-triggered cell FDRE clocked by pll_dac_clk_1x  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            oddr_dac_dat[0]/D2
@@ -475,10 +485,10 @@ Slack (MET) :             1.521ns  (required time - arrival time)
   Path Group:             pll_dac_clk_1x
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_dac_clk_1x fall@4.000ns - pll_dac_clk_1x rise@0.000ns)
-  Data Path Delay:        1.256ns  (logic 0.456ns (36.310%)  route 0.800ns (63.690%))
+  Data Path Delay:        1.256ns  (logic 0.456ns (36.314%)  route 0.800ns (63.686%))
   Logic Levels:           0  
-  Clock Path Skew:        -0.145ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    2.969ns = ( 6.969 - 4.000 ) 
+  Clock Path Skew:        -0.040ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    3.074ns = ( 7.074 - 4.000 ) 
     Source Clock Delay      (SCD):    3.357ns
     Clock Pessimism Removal (CPR):    0.243ns
   Clock Uncertainty:      0.069ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
@@ -502,7 +512,7 @@ Slack (MET) :             1.521ns  (required time - arrival time)
                          FDRE                                         r  dac_dat_a_reg[0]/C
   -------------------------------------------------------------------    -------------------
                          FDRE (Prop_fdre_C_Q)         0.456     3.813 r  dac_dat_a_reg[0]/Q
-                         net (fo=1, unplaced)         0.800     4.613    dac_dat_a[0]
+                         net (fo=1, unplaced)         0.800     4.612    dac_dat_a[0]
     OLOGIC_X0Y86         ODDR                                         r  oddr_dac_dat[0]/D2
   -------------------------------------------------------------------    -------------------
 
@@ -516,16 +526,16 @@ Slack (MET) :             1.521ns  (required time - arrival time)
                                                       0.084     5.463 f  pll/pll/CLKOUT1
                          net (fo=1, unplaced)         0.760     6.223    pll_dac_clk_1x
                          BUFG (Prop_bufg_I_O)         0.091     6.314 f  bufg_dac_clk_1x/O
-                         net (fo=45, unplaced)        0.655     6.969    dac_clk_1x
+                         net (fo=45, unplaced)        0.760     7.074    dac_clk_1x
     OLOGIC_X0Y86         ODDR                                         f  oddr_dac_dat[0]/C
-                         clock pessimism              0.243     7.212    
-                         clock uncertainty           -0.069     7.143    
-    OLOGIC_X0Y86         ODDR (Setup_oddr_C_D2)      -1.009     6.134    oddr_dac_dat[0]
+                         clock pessimism              0.243     7.317    
+                         clock uncertainty           -0.069     7.248    
+    OLOGIC_X0Y86         ODDR (Setup_oddr_C_D2)      -1.009     6.239    oddr_dac_dat[0]
   -------------------------------------------------------------------
-                         required time                          6.134    
-                         arrival time                          -4.613    
+                         required time                          6.239    
+                         arrival time                          -4.612    
   -------------------------------------------------------------------
-                         slack                                  1.521    
+                         slack                                  1.626    
 
 
 
@@ -541,11 +551,11 @@ Slack (VIOLATED) :        -0.089ns  (arrival time - required time)
   Path Group:             pll_dac_clk_1x
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_dac_clk_1x rise@0.000ns - pll_dac_clk_1x rise@0.000ns)
-  Data Path Delay:        0.478ns  (logic 0.141ns (29.488%)  route 0.337ns (70.512%))
+  Data Path Delay:        0.478ns  (logic 0.141ns (29.492%)  route 0.337ns (70.508%))
   Logic Levels:           0  
   Clock Path Skew:        0.145ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    1.485ns
-    Source Clock Delay      (SCD):    1.140ns
+    Source Clock Delay      (SCD):    1.139ns
     Clock Pessimism Removal (CPR):    0.200ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
@@ -560,10 +570,10 @@ Slack (VIOLATED) :        -0.089ns  (arrival time - required time)
                                                       0.051     0.566 r  pll/pll/CLKOUT1
                          net (fo=1, unplaced)         0.337     0.904    pll_dac_clk_1x
                          BUFG (Prop_bufg_I_O)         0.026     0.930 r  bufg_dac_clk_1x/O
-                         net (fo=45, unplaced)        0.210     1.140    dac_clk_1x
+                         net (fo=45, unplaced)        0.210     1.139    dac_clk_1x
                          FDRE                                         r  dac_rst_reg/C
   -------------------------------------------------------------------    -------------------
-                         FDRE (Prop_fdre_C_Q)         0.141     1.281 r  dac_rst_reg/Q
+                         FDRE (Prop_fdre_C_Q)         0.141     1.280 r  dac_rst_reg/Q
                          net (fo=17, unplaced)        0.337     1.618    dac_rst
     OLOGIC_X0Y86         ODDR                                         r  oddr_dac_dat[0]/R
   -------------------------------------------------------------------    -------------------
@@ -580,10 +590,10 @@ Slack (VIOLATED) :        -0.089ns  (arrival time - required time)
                          BUFG (Prop_bufg_I_O)         0.029     1.130 r  bufg_dac_clk_1x/O
                          net (fo=45, unplaced)        0.355     1.485    dac_clk_1x
     OLOGIC_X0Y86         ODDR                                         r  oddr_dac_dat[0]/C
-                         clock pessimism             -0.200     1.285    
-    OLOGIC_X0Y86         ODDR (Hold_oddr_C_R)         0.422     1.707    oddr_dac_dat[0]
+                         clock pessimism             -0.200     1.284    
+    OLOGIC_X0Y86         ODDR (Hold_oddr_C_R)         0.422     1.706    oddr_dac_dat[0]
   -------------------------------------------------------------------
-                         required time                         -1.707    
+                         required time                         -1.706    
                          arrival time                           1.618    
   -------------------------------------------------------------------
                          slack                                 -0.089    
@@ -602,7 +612,7 @@ Sources:            { pll/pll/CLKOUT1 }
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location  Pin
 Min Period        n/a     BUFG/I             n/a            2.155         8.000       5.845                bufg_dac_clk_1x/I
 Max Period        n/a     PLLE2_ADV/CLKOUT1  n/a            160.000       8.000       152.000              pll/pll/CLKOUT1
-Low Pulse Width   Fast    FDRE/C             n/a            0.500         4.000       3.500                dac_dat_a_reg[0]/C
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         4.000       3.500                dac_dat_a_reg[0]/C
 High Pulse Width  Slow    FDRE/C             n/a            0.500         4.000       3.500                dac_dat_a_reg[0]/C
 
 
@@ -657,7 +667,7 @@ Max Period  n/a     PLLE2_ADV/CLKOUT2  n/a            160.000       4.000       
 From Clock:  pll_pwm_clk
   To Clock:  pll_pwm_clk
 
-Setup :            4  Failing Endpoints,  Worst Slack       -0.466ns,  Total Violation       -1.862ns
+Setup :            4  Failing Endpoints,  Worst Slack       -0.363ns,  Total Violation       -1.454ns
 Hold  :            0  Failing Endpoints,  Worst Slack        0.126ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        1.500ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
@@ -665,7 +675,7 @@ PW    :            0  Failing Endpoints,  Worst Slack        1.500ns,  Total Vio
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.466ns  (required time - arrival time)
+Slack (VIOLATED) :        -0.363ns  (required time - arrival time)
   Source:                 pwm[0]/vcnt_r_reg[0]/C
                             (rising edge-triggered cell FDRE clocked by pll_pwm_clk  {rise@0.000ns fall@2.000ns period=4.000ns})
   Destination:            pwm[0]/pwm_o_reg/D
@@ -673,10 +683,10 @@ Slack (VIOLATED) :        -0.466ns  (required time - arrival time)
   Path Group:             pll_pwm_clk
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            4.000ns  (pll_pwm_clk rise@4.000ns - pll_pwm_clk rise@0.000ns)
-  Data Path Delay:        3.175ns  (logic 1.623ns (51.120%)  route 1.552ns (48.880%))
+  Data Path Delay:        3.184ns  (logic 1.632ns (51.261%)  route 1.552ns (48.739%))
   Logic Levels:           3  (CARRY4=2 LUT4=1)
-  Clock Path Skew:        -0.145ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    2.969ns = ( 6.969 - 4.000 ) 
+  Clock Path Skew:        -0.040ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    3.074ns = ( 7.074 - 4.000 ) 
     Source Clock Delay      (SCD):    3.357ns
     Clock Pessimism Removal (CPR):    0.243ns
   Clock Uncertainty:      0.063ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
@@ -701,14 +711,14 @@ Slack (VIOLATED) :        -0.466ns  (required time - arrival time)
   -------------------------------------------------------------------    -------------------
                          FDRE (Prop_fdre_C_Q)         0.456     3.813 f  pwm[0]/vcnt_r_reg[0]/Q
                          net (fo=2, unplaced)         0.752     4.565    pwm[0]/vcnt_r[0]
-                         LUT4 (Prop_lut4_I1_O)        0.321     4.886 r  pwm[0]/pwm_o_i_8/O
-                         net (fo=1, unplaced)         0.000     4.886    pwm[0]/pwm_o_i_8_n_0
+                         LUT4 (Prop_lut4_I1_O)        0.319     4.884 r  pwm[0]/pwm_o_i_8/O
+                         net (fo=1, unplaced)         0.000     4.884    pwm[0]/pwm_o_i_8_n_0
                          CARRY4 (Prop_carry4_DI[0]_CO[3])
-                                                      0.553     5.439 r  pwm[0]/pwm_o_reg_i_3/CO[3]
-                         net (fo=1, unplaced)         0.000     5.439    pwm[0]/pwm_o_reg_i_3_n_0
+                                                      0.576     5.460 r  pwm[0]/pwm_o_reg_i_3/CO[3]
+                         net (fo=1, unplaced)         0.000     5.460    pwm[0]/pwm_o_reg_i_3_n_0
                          CARRY4 (Prop_carry4_CI_CO[0])
-                                                      0.293     5.732 r  pwm[0]/pwm_o_reg_i_2/CO[0]
-                         net (fo=1, unplaced)         0.800     6.532    pwm[0]/p_1_in
+                                                      0.281     5.741 r  pwm[0]/pwm_o_reg_i_2/CO[0]
+                         net (fo=1, unplaced)         0.800     6.540    pwm[0]/p_1_in
     OLOGIC_X0Y47         FDRE                                         r  pwm[0]/pwm_o_reg/D
   -------------------------------------------------------------------    -------------------
 
@@ -722,16 +732,16 @@ Slack (VIOLATED) :        -0.466ns  (required time - arrival time)
                                                       0.084     5.463 r  pll/pll/CLKOUT5
                          net (fo=1, unplaced)         0.760     6.223    pll_pwm_clk
                          BUFG (Prop_bufg_I_O)         0.091     6.314 r  bufg_pwm_clk/O
-                         net (fo=215, unplaced)       0.655     6.969    pwm[0]/clk
+                         net (fo=215, unplaced)       0.760     7.074    pwm[0]/clk
     OLOGIC_X0Y47         FDRE                                         r  pwm[0]/pwm_o_reg/C
-                         clock pessimism              0.243     7.212    
-                         clock uncertainty           -0.063     7.149    
-    OLOGIC_X0Y47         FDRE (Setup_fdre_C_D)       -1.083     6.066    pwm[0]/pwm_o_reg
+                         clock pessimism              0.243     7.317    
+                         clock uncertainty           -0.063     7.254    
+    OLOGIC_X0Y47         FDRE (Setup_fdre_C_D)       -1.077     6.177    pwm[0]/pwm_o_reg
   -------------------------------------------------------------------
-                         required time                          6.066    
-                         arrival time                          -6.532    
+                         required time                          6.177    
+                         arrival time                          -6.540    
   -------------------------------------------------------------------
-                         slack                                 -0.466    
+                         slack                                 -0.363    
 
 
 
@@ -747,11 +757,11 @@ Slack (MET) :             0.126ns  (arrival time - required time)
   Path Group:             pll_pwm_clk
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_pwm_clk rise@0.000ns - pll_pwm_clk rise@0.000ns)
-  Data Path Delay:        0.747ns  (logic 0.239ns (32.000%)  route 0.508ns (68.000%))
+  Data Path Delay:        0.747ns  (logic 0.239ns (32.003%)  route 0.508ns (67.997%))
   Logic Levels:           1  (LUT1=1)
   Clock Path Skew:        0.145ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    1.485ns
-    Source Clock Delay      (SCD):    1.140ns
+    Source Clock Delay      (SCD):    1.139ns
     Clock Pessimism Removal (CPR):    0.200ns
 
     Location             Delay type                Incr(ns)  Path(ns)    Netlist Resource(s)
@@ -766,10 +776,10 @@ Slack (MET) :             0.126ns  (arrival time - required time)
                                                       0.051     0.566 r  pll/pll/CLKOUT5
                          net (fo=1, unplaced)         0.337     0.904    pll_pwm_clk
                          BUFG (Prop_bufg_I_O)         0.026     0.930 r  bufg_pwm_clk/O
-                         net (fo=215, unplaced)       0.210     1.140    pwm_clk
+                         net (fo=215, unplaced)       0.210     1.139    pwm_clk
                          FDRE                                         r  pwm_rstn_reg/C
   -------------------------------------------------------------------    -------------------
-                         FDRE (Prop_fdre_C_Q)         0.141     1.281 f  pwm_rstn_reg/Q
+                         FDRE (Prop_fdre_C_Q)         0.141     1.280 f  pwm_rstn_reg/Q
                          net (fo=80, unplaced)        0.171     1.451    pwm[0]/rstn
                          LUT1 (Prop_lut1_I0_O)        0.098     1.549 r  pwm[0]/pwm_o_i_1/O
                          net (fo=13, unplaced)        0.337     1.886    pwm[0]/clear
@@ -788,10 +798,10 @@ Slack (MET) :             0.126ns  (arrival time - required time)
                          BUFG (Prop_bufg_I_O)         0.029     1.130 r  bufg_pwm_clk/O
                          net (fo=215, unplaced)       0.355     1.485    pwm[0]/clk
     OLOGIC_X0Y47         FDRE                                         r  pwm[0]/pwm_o_reg/C
-                         clock pessimism             -0.200     1.285    
-    OLOGIC_X0Y47         FDRE (Hold_fdre_C_R)         0.476     1.761    pwm[0]/pwm_o_reg
+                         clock pessimism             -0.200     1.284    
+    OLOGIC_X0Y47         FDRE (Hold_fdre_C_R)         0.476     1.760    pwm[0]/pwm_o_reg
   -------------------------------------------------------------------
-                         required time                         -1.761    
+                         required time                         -1.760    
                          arrival time                           1.886    
   -------------------------------------------------------------------
                          slack                                  0.126    
@@ -810,8 +820,8 @@ Sources:            { pll/pll/CLKOUT5 }
 Check Type        Corner  Lib Pin            Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location  Pin
 Min Period        n/a     BUFG/I             n/a            2.155         4.000       1.845                bufg_pwm_clk/I
 Max Period        n/a     PLLE2_ADV/CLKOUT5  n/a            160.000       4.000       156.000              pll/pll/CLKOUT5
-Low Pulse Width   Slow    FDRE/C             n/a            0.500         2.000       1.500                pwm[0]/b_reg[0]/C
-High Pulse Width  Fast    FDRE/C             n/a            0.500         2.000       1.500                pwm[0]/b_reg[0]/C
+Low Pulse Width   Slow    FDRE/C             n/a            0.500         2.000       1.500                pwm_rstn_reg/C
+High Pulse Width  Slow    FDRE/C             n/a            0.500         2.000       1.500                pwm_rstn_reg/C
 
 
 
@@ -908,27 +918,27 @@ Min Period  n/a     BUFG/I   n/a            2.155         20.000      17.845    
 From Clock:  clk_fpga_3
   To Clock:  clk_fpga_3
 
-Setup :           20  Failing Endpoints,  Worst Slack       -0.672ns,  Total Violation       -7.546ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.007ns,  Total Violation        0.000ns
+Setup :            8  Failing Endpoints,  Worst Slack       -0.169ns,  Total Violation       -1.351ns
+Hold  :            0  Failing Endpoints,  Worst Slack        0.045ns,  Total Violation        0.000ns
 PW    :            0  Failing Endpoints,  Worst Slack        1.000ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.672ns  (required time - arrival time)
-  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]_rep__1/C
-                            (rising edge-triggered cell FDSE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
-  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/D
+Slack (VIOLATED) :        -0.169ns  (required time - arrival time)
+  Source:                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/memory_reg[3][3]_srl4/CLK
+                            (rising edge-triggered cell SRL16E clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
+  Destination:            i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[0]/R
                             (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
   Path Group:             clk_fpga_3
   Path Type:              Setup (Max at Slow Process Corner)
   Requirement:            5.000ns  (clk_fpga_3 rise@5.000ns - clk_fpga_3 rise@0.000ns)
-  Data Path Delay:        5.506ns  (logic 2.960ns (53.760%)  route 2.546ns (46.240%))
-  Logic Levels:           8  (CARRY4=4 LUT2=1 LUT3=1 LUT4=1 LUT5=1)
+  Data Path Delay:        4.508ns  (logic 1.876ns (41.615%)  route 2.632ns (58.385%))
+  Logic Levels:           2  (LUT4=1 LUT6=1)
   Clock Path Skew:        -0.145ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    1.506ns = ( 6.506 - 5.000 ) 
-    Source Clock Delay      (SCD):    1.701ns
+    Destination Clock Delay (DCD):    1.505ns = ( 6.505 - 5.000 ) 
+    Source Clock Delay      (SCD):    1.700ns
     Clock Pessimism Removal (CPR):    0.050ns
   Clock Uncertainty:      0.083ns  ((TSJ^2 + TIJ^2)^1/2 + DJ) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -943,32 +953,17 @@ Slack (VIOLATED) :        -0.672ns  (required time - arrival time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, unplaced)         0.800     0.800    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
                          BUFG (Prop_bufg_I_O)         0.101     0.901 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=991, unplaced)       0.800     1.701    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/clk
-                         FDSE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]_rep__1/C
+                         net (fo=752, unplaced)       0.800     1.700    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/clk
+                         SRL16E                                       r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/memory_reg[3][3]_srl4/CLK
   -------------------------------------------------------------------    -------------------
-                         FDSE (Prop_fdse_C_Q)         0.456     2.157 f  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]_rep__1/Q
-                         net (fo=3, unplaced)         0.488     2.645    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/cnt_read_reg[1]_rep__1_n_0
-                         LUT2 (Prop_lut2_I0_O)        0.295     2.940 f  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/full_INST_0/O
-                         net (fo=4, unplaced)         0.926     3.866    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/b_full
-                         LUT5 (Prop_lut5_I1_O)        0.150     4.016 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/aw_cmd_fsm_0/next_INST_0/O
-                         net (fo=25, unplaced)        0.514     4.530    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/next
-                         LUT4 (Prop_lut4_I3_O)        0.124     4.654 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[0]_i_17/O
-                         net (fo=1, unplaced)         0.000     4.654    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[0]_i_17_n_0
-                         CARRY4 (Prop_carry4_S[1]_CO[3])
-                                                      0.550     5.204 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]_i_11/CO[3]
-                         net (fo=1, unplaced)         0.000     5.204    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[0]_i_11_n_0
-                         CARRY4 (Prop_carry4_CI_O[3])
-                                                      0.329     5.533 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_6/O[3]
-                         net (fo=1, unplaced)         0.618     6.151    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/C[7]
-                         LUT3 (Prop_lut3_I0_O)        0.307     6.458 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[4]_i_2/O
-                         net (fo=1, unplaced)         0.000     6.458    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr[4]_i_2_n_0
-                         CARRY4 (Prop_carry4_S[3]_CO[3])
-                                                      0.401     6.859 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_1/CO[3]
-                         net (fo=1, unplaced)         0.000     6.859    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[4]_i_1_n_0
-                         CARRY4 (Prop_carry4_CI_O[1])
-                                                      0.348     7.207 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]_i_1/O[1]
-                         net (fo=1, unplaced)         0.000     7.207    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[8]_i_1_n_6
-                         FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/D
+                         SRL16E (Prop_srl16e_CLK_Q)
+                                                      1.628     3.328 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0/memory_reg[3][3]_srl4/Q
+                         net (fo=1, unplaced)         0.902     4.230    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bid_fifo_0_n_16
+                         LUT4 (Prop_lut4_I1_O)        0.124     4.354 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_fifo_0_i_2/O
+                         net (fo=2, unplaced)         0.913     5.267    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_fifo_0_i_2_n_0
+                         LUT6 (Prop_lut6_I2_O)        0.124     5.391 r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt[7]_i_1/O
+                         net (fo=9, unplaced)         0.817     6.208    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/s_bresp_acc0
+                         FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[0]/R
   -------------------------------------------------------------------    -------------------
 
                          (clock clk_fpga_3 rise edge)
@@ -976,16 +971,16 @@ Slack (VIOLATED) :        -0.672ns  (required time - arrival time)
     PS7_X0Y0             PS7                          0.000     5.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, unplaced)         0.760     5.760    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
                          BUFG (Prop_bufg_I_O)         0.091     5.851 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=991, unplaced)       0.655     6.506    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/clk
-                         FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]/C
-                         clock pessimism              0.050     6.556    
+                         net (fo=752, unplaced)       0.655     6.505    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/clk
+                         FDRE                                         r  i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[0]/C
+                         clock pessimism              0.050     6.555    
                          clock uncertainty           -0.083     6.473    
-                         FDRE (Setup_fdre_C_D)        0.062     6.535    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.aw_channel_0/cmd_translator_0/incr_cmd_0/axaddr_incr_reg[9]
+                         FDRE (Setup_fdre_C_R)       -0.433     6.040    i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/WR.b_channel_0/bresp_cnt_reg[0]
   -------------------------------------------------------------------
-                         required time                          6.535    
-                         arrival time                          -7.207    
+                         required time                          6.040    
+                         arrival time                          -6.208    
   -------------------------------------------------------------------
-                         slack                                 -0.672    
+                         slack                                 -0.169    
 
 
 
@@ -993,15 +988,15 @@ Slack (VIOLATED) :        -0.672ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.007ns  (arrival time - required time)
-  Source:                 i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/C
+Slack (MET) :             0.045ns  (arrival time - required time)
+  Source:                 i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/C
                             (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
-  Destination:            i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/D
+  Destination:            i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/D
                             (rising edge-triggered cell FDRE clocked by clk_fpga_3  {rise@0.000ns fall@2.500ns period=5.000ns})
   Path Group:             clk_fpga_3
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (clk_fpga_3 rise@0.000ns - clk_fpga_3 rise@0.000ns)
-  Data Path Delay:        0.222ns  (logic 0.141ns (63.413%)  route 0.081ns (36.587%))
+  Data Path Delay:        0.228ns  (logic 0.147ns (64.493%)  route 0.081ns (35.507%))
   Logic Levels:           0  
   Clock Path Skew:        0.145ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    0.739ns
@@ -1015,12 +1010,12 @@ Slack (MET) :             0.007ns  (arrival time - required time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, unplaced)         0.337     0.337    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
                          BUFG (Prop_bufg_I_O)         0.026     0.363 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=991, unplaced)       0.210     0.573    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/scndry_aclk
-                         FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/C
+                         net (fo=752, unplaced)       0.210     0.573    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/scndry_aclk
+                         FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/C
   -------------------------------------------------------------------    -------------------
-                         FDRE (Prop_fdre_C_Q)         0.141     0.714 r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/Q
-                         net (fo=1, unplaced)         0.081     0.795    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/D
-                         FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/D
+                         FDRE (Prop_fdre_C_Q)         0.147     0.720 r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_IN_cdc_to/Q
+                         net (fo=1, unplaced)         0.081     0.801    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/Q
+                         FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/D
   -------------------------------------------------------------------    -------------------
 
                          (clock clk_fpga_3 rise edge)
@@ -1028,15 +1023,15 @@ Slack (MET) :             0.007ns  (arrival time - required time)
     PS7_X0Y0             PS7                          0.000     0.000 r  i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKCLK[3]
                          net (fo=1, unplaced)         0.355     0.355    i_ps/system_i/system_i/processing_system7/inst/FCLK_CLK_unbuffered[3]
                          BUFG (Prop_bufg_I_O)         0.029     0.384 r  i_ps/system_i/system_i/processing_system7/inst/buffer_fclk_clk_3.FCLK_CLK_3_BUFG/O
-                         net (fo=991, unplaced)       0.355     0.739    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/scndry_aclk
-                         FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/C
+                         net (fo=752, unplaced)       0.355     0.739    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/scndry_aclk
+                         FDRE                                         r  i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2/C
                          clock pessimism             -0.021     0.718    
-                         FDRE (Hold_fdre_C_D)         0.070     0.788    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_AUX.ACT_LO_AUX/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2
+                         FDRE (Hold_fdre_C_D)         0.038     0.756    i_ps/system_i/system_i/proc_sys_reset/U0/EXT_LPF/ACTIVE_LOW_EXT.ACT_LO_EXT/GENERATE_LEVEL_P_S_CDC.SINGLE_BIT.CROSS_PLEVEL_IN2SCNDRY_s_level_out_d2
   -------------------------------------------------------------------
-                         required time                         -0.788    
-                         arrival time                           0.795    
+                         required time                         -0.756    
+                         arrival time                           0.801    
   -------------------------------------------------------------------
-                         slack                                  0.007    
+                         slack                                  0.045    
 
 
 
@@ -1052,7 +1047,7 @@ Sources:            { i_ps/system_i/system_i/processing_system7/inst/PS7_i/FCLKC
 Check Type        Corner  Lib Pin      Reference Pin  Required(ns)  Actual(ns)  Slack(ns)  Location   Pin
 Min Period        n/a     XADC/DCLK    n/a            4.000         5.000       1.000      XADC_X0Y0  i_ps/system_i/system_i/xadc/inst/AXI_XADC_CORE_I/XADC_INST/DCLK
 Low Pulse Width   Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
-High Pulse Width  Fast    SRLC32E/CLK  n/a            0.980         2.500       1.520                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
+High Pulse Width  Slow    SRLC32E/CLK  n/a            0.980         2.500       1.520                 i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/rd_data_fifo_0/memory_reg[31][0]_srl32/CLK
 
 
 
@@ -1060,14 +1055,14 @@ High Pulse Width  Fast    SRLC32E/CLK  n/a            0.980         2.500       
 From Clock:  adc_clk
   To Clock:  pll_adc_clk
 
-Setup :            0  Failing Endpoints,  Worst Slack        5.085ns,  Total Violation        0.000ns
-Hold  :            0  Failing Endpoints,  Worst Slack        0.490ns,  Total Violation        0.000ns
+Setup :            0  Failing Endpoints,  Worst Slack        4.849ns,  Total Violation        0.000ns
+Hold  :            0  Failing Endpoints,  Worst Slack        1.266ns,  Total Violation        0.000ns
 ---------------------------------------------------------------------------------------------------
 
 
 Max Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             5.085ns  (required time - arrival time)
+Slack (MET) :             4.849ns  (required time - arrival time)
   Source:                 adc_dat_a_i[7]
                             (input port clocked by adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            adc_dat_a_reg[5]/D
@@ -1075,11 +1070,11 @@ Slack (MET) :             5.085ns  (required time - arrival time)
   Path Group:             pll_adc_clk
   Path Type:              Setup (Max at Fast Process Corner)
   Requirement:            8.000ns  (pll_adc_clk rise@8.000ns - adc_clk rise@0.000ns)
-  Data Path Delay:        0.488ns  (logic 0.488ns (100.000%)  route 0.000ns (0.000%))
+  Data Path Delay:        0.850ns  (logic 0.488ns (57.440%)  route 0.362ns (42.560%))
   Logic Levels:           1  (IBUF=1)
   Input Delay:            3.400ns
-  Clock Path Skew:        1.140ns (DCD - SCD + CPR)
-    Destination Clock Delay (DCD):    1.140ns = ( 9.140 - 8.000 ) 
+  Clock Path Skew:        1.267ns (DCD - SCD + CPR)
+    Destination Clock Delay (DCD):    1.267ns = ( 9.267 - 8.000 ) 
     Source Clock Delay      (SCD):    0.000ns
     Clock Pessimism Removal (CPR):    0.000ns
   Clock Uncertainty:      0.166ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
@@ -1094,7 +1089,7 @@ Slack (MET) :             5.085ns  (required time - arrival time)
     Y14                                               0.000     3.400 r  adc_dat_a_i[7] (IN)
                          net (fo=0)                   0.000     3.400    adc_dat_a_i[7]
     Y14                  IBUF (Prop_ibuf_I_O)         0.488     3.888 r  adc_dat_a_i_IBUF[7]_inst/O
-                         net (fo=1, estimated)        0.000     3.888    adc_dat_a_i_IBUF[7]
+                         net (fo=1, estimated)        0.362     4.250    adc_dat_a_i_IBUF[7]
     ILOGIC_X0Y33         FDRE                                         r  adc_dat_a_reg[5]/D
   -------------------------------------------------------------------    -------------------
 
@@ -1108,16 +1103,16 @@ Slack (MET) :             5.085ns  (required time - arrival time)
                                                       0.051     8.566 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.337     8.904    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.026     8.930 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.210     9.140    adc_clk
+                         net (fo=13129, unplaced)     0.337     9.267    adc_clk
     ILOGIC_X0Y33         FDRE                                         r  adc_dat_a_reg[5]/C
-                         clock pessimism              0.000     9.140    
-                         clock uncertainty           -0.166     8.974    
-    ILOGIC_X0Y33         FDRE (Setup_fdre_C_D)       -0.001     8.973    adc_dat_a_reg[5]
+                         clock pessimism              0.000     9.267    
+                         clock uncertainty           -0.166     9.101    
+    ILOGIC_X0Y33         FDRE (Setup_fdre_C_D)       -0.002     9.099    adc_dat_a_reg[5]
   -------------------------------------------------------------------
-                         required time                          8.973    
-                         arrival time                          -3.888    
+                         required time                          9.099    
+                         arrival time                          -4.250    
   -------------------------------------------------------------------
-                         slack                                  5.085    
+                         slack                                  4.849    
 
 
 
@@ -1125,7 +1120,7 @@ Slack (MET) :             5.085ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (MET) :             0.490ns  (arrival time - required time)
+Slack (MET) :             1.266ns  (arrival time - required time)
   Source:                 adc_dat_b_i[3]
                             (input port clocked by adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            adc_dat_b_reg[1]/D
@@ -1133,7 +1128,7 @@ Slack (MET) :             0.490ns  (arrival time - required time)
   Path Group:             pll_adc_clk
   Path Type:              Hold (Min at Slow Process Corner)
   Requirement:            0.000ns  (pll_adc_clk rise@0.000ns - adc_clk rise@0.000ns)
-  Data Path Delay:        0.805ns  (logic 0.805ns (100.000%)  route 0.000ns (0.000%))
+  Data Path Delay:        1.579ns  (logic 0.805ns (50.978%)  route 0.774ns (49.022%))
   Logic Levels:           1  (IBUF=1)
   Input Delay:            3.400ns
   Clock Path Skew:        3.357ns (DCD - SCD - CPR)
@@ -1152,7 +1147,7 @@ Slack (MET) :             0.490ns  (arrival time - required time)
     P16                                               0.000     3.400 r  adc_dat_b_i[3] (IN)
                          net (fo=0)                   0.000     3.400    adc_dat_b_i[3]
     P16                  IBUF (Prop_ibuf_I_O)         0.805     4.205 r  adc_dat_b_i_IBUF[3]_inst/O
-                         net (fo=1, estimated)        0.000     4.205    adc_dat_b_i_IBUF[3]
+                         net (fo=1, estimated)        0.774     4.979    adc_dat_b_i_IBUF[3]
     ILOGIC_X0Y1          FDRE                                         r  adc_dat_b_reg[1]/D
   -------------------------------------------------------------------    -------------------
 
@@ -1166,16 +1161,16 @@ Slack (MET) :             0.490ns  (arrival time - required time)
                                                       0.089     1.656 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.800     2.456    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.101     2.557 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.800     3.357    adc_clk
+                         net (fo=13129, unplaced)     0.800     3.357    adc_clk
     ILOGIC_X0Y1          FDRE                                         r  adc_dat_b_reg[1]/C
                          clock pessimism              0.000     3.357    
-                         clock uncertainty            0.166     3.523    
-    ILOGIC_X0Y1          FDRE (Hold_fdre_C_D)         0.192     3.715    adc_dat_b_reg[1]
+                         clock uncertainty            0.166     3.522    
+    ILOGIC_X0Y1          FDRE (Hold_fdre_C_D)         0.191     3.713    adc_dat_b_reg[1]
   -------------------------------------------------------------------
-                         required time                         -3.715    
-                         arrival time                           4.205    
+                         required time                         -3.713    
+                         arrival time                           4.979    
   -------------------------------------------------------------------
-                         slack                                  0.490    
+                         slack                                  1.266    
 
 
 
@@ -1186,7 +1181,7 @@ From Clock:  pll_adc_clk
   To Clock:  pll_dac_clk_1x
 
 Setup :            0  Failing Endpoints,  Worst Slack        5.303ns,  Total Violation        0.000ns
-Hold  :            2  Failing Endpoints,  Worst Slack       -0.026ns,  Total Violation       -0.053ns
+Hold  :            2  Failing Endpoints,  Worst Slack       -0.027ns,  Total Violation       -0.054ns
 ---------------------------------------------------------------------------------------------------
 
 
@@ -1223,7 +1218,7 @@ Slack (MET) :             5.303ns  (required time - arrival time)
                                                       0.089     1.656 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.800     2.456    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.101     2.557 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.800     3.357    i_dsp/clk_i
+                         net (fo=13129, unplaced)     0.800     3.357    i_dsp/clk_i
                          FDRE                                         r  i_dsp/sum1_reg[10]/C
   -------------------------------------------------------------------    -------------------
                          FDRE (Prop_fdre_C_Q)         0.456     3.813 f  i_dsp/sum1_reg[10]/Q
@@ -1262,7 +1257,7 @@ Slack (MET) :             5.303ns  (required time - arrival time)
 
 Min Delay Paths
 --------------------------------------------------------------------------------------
-Slack (VIOLATED) :        -0.026ns  (arrival time - required time)
+Slack (VIOLATED) :        -0.027ns  (arrival time - required time)
   Source:                 i_dsp/sum1_reg[17]/C
                             (rising edge-triggered cell FDRE clocked by pll_adc_clk  {rise@0.000ns fall@4.000ns period=8.000ns})
   Destination:            dac_dat_a_reg[13]/D
@@ -1270,11 +1265,11 @@ Slack (VIOLATED) :        -0.026ns  (arrival time - required time)
   Path Group:             pll_dac_clk_1x
   Path Type:              Hold (Min at Fast Process Corner)
   Requirement:            0.000ns  (pll_dac_clk_1x rise@0.000ns - pll_adc_clk rise@0.000ns)
-  Data Path Delay:        0.311ns  (logic 0.141ns (45.295%)  route 0.170ns (54.705%))
+  Data Path Delay:        0.311ns  (logic 0.141ns (45.356%)  route 0.170ns (54.644%))
   Logic Levels:           0  
   Clock Path Skew:        0.166ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    1.485ns
-    Source Clock Delay      (SCD):    1.140ns
+    Source Clock Delay      (SCD):    1.139ns
     Clock Pessimism Removal (CPR):    0.179ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1293,11 +1288,11 @@ Slack (VIOLATED) :        -0.026ns  (arrival time - required time)
                                                       0.051     0.566 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.337     0.904    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.026     0.930 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.210     1.140    i_dsp/clk_i
+                         net (fo=13129, unplaced)     0.210     1.139    i_dsp/clk_i
                          FDRE                                         r  i_dsp/sum1_reg[17]/C
   -------------------------------------------------------------------    -------------------
-                         FDRE (Prop_fdre_C_Q)         0.141     1.281 r  i_dsp/sum1_reg[17]/Q
-                         net (fo=29, unplaced)        0.170     1.451    dac_a[13]
+                         FDRE (Prop_fdre_C_Q)         0.141     1.280 r  i_dsp/sum1_reg[17]/Q
+                         net (fo=29, unplaced)        0.170     1.450    dac_a[13]
                          FDRE                                         r  dac_dat_a_reg[13]/D
   -------------------------------------------------------------------    -------------------
 
@@ -1318,9 +1313,9 @@ Slack (VIOLATED) :        -0.026ns  (arrival time - required time)
                          FDRE (Hold_fdre_C_D)        -0.017     1.477    dac_dat_a_reg[13]
   -------------------------------------------------------------------
                          required time                         -1.477    
-                         arrival time                           1.451    
+                         arrival time                           1.450    
   -------------------------------------------------------------------
-                         slack                                 -0.026    
+                         slack                                 -0.027    
 
 
 
@@ -1331,7 +1326,7 @@ From Clock:  pll_adc_clk
   To Clock:  pll_pwm_clk
 
 Setup :            0  Failing Endpoints,  Worst Slack        2.077ns,  Total Violation        0.000ns
-Hold  :           90  Failing Endpoints,  Worst Slack       -0.071ns,  Total Violation       -5.739ns
+Hold  :           90  Failing Endpoints,  Worst Slack       -0.071ns,  Total Violation       -5.752ns
 ---------------------------------------------------------------------------------------------------
 
 
@@ -1368,13 +1363,13 @@ Slack (MET) :             2.077ns  (required time - arrival time)
                                                       0.089     1.656 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.800     2.456    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.101     2.557 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.800     3.357    i_ams/clk_i
+                         net (fo=13129, unplaced)     0.800     3.357    i_ams/clk_i
                          FDRE                                         r  i_ams/dac_a_o_reg[14]/C
   -------------------------------------------------------------------    -------------------
                          FDRE (Prop_fdre_C_Q)         0.456     3.813 r  i_ams/dac_a_o_reg[14]/Q
                          net (fo=2, unplaced)         0.817     4.630    pwm[0]/cfg[14]
                          LUT5 (Prop_lut5_I0_O)        0.295     4.925 r  pwm[0]/b[14]_i_2/O
-                         net (fo=1, unplaced)         0.000     4.925    pwm[0]/b[14]_i_2_n_0
+                         net (fo=1, unplaced)         0.000     4.925    pwm[0]/p_0_in[14]
                          FDRE                                         r  pwm[0]/b_reg[14]/D
   -------------------------------------------------------------------    -------------------
 
@@ -1417,7 +1412,7 @@ Slack (VIOLATED) :        -0.071ns  (arrival time - required time)
   Logic Levels:           1  (LUT6=1)
   Clock Path Skew:        0.166ns (DCD - SCD - CPR)
     Destination Clock Delay (DCD):    1.485ns
-    Source Clock Delay      (SCD):    1.140ns
+    Source Clock Delay      (SCD):    1.139ns
     Clock Pessimism Removal (CPR):    0.179ns
   Clock Uncertainty:      0.189ns  ((TSJ^2 + DJ^2)^1/2) / 2 + PE
     Total System Jitter     (TSJ):    0.071ns
@@ -1436,13 +1431,13 @@ Slack (VIOLATED) :        -0.071ns  (arrival time - required time)
                                                       0.051     0.566 r  pll/pll/CLKOUT0
                          net (fo=1, unplaced)         0.337     0.904    pll_adc_clk
                          BUFG (Prop_bufg_I_O)         0.026     0.930 r  bufg_adc_clk/O
-                         net (fo=13384, unplaced)     0.210     1.140    i_ams/clk_i
+                         net (fo=13129, unplaced)     0.210     1.139    i_ams/clk_i
                          FDRE                                         r  i_ams/dac_a_o_reg[0]/C
   -------------------------------------------------------------------    -------------------
-                         FDRE (Prop_fdre_C_Q)         0.141     1.281 r  i_ams/dac_a_o_reg[0]/Q
+                         FDRE (Prop_fdre_C_Q)         0.141     1.280 r  i_ams/dac_a_o_reg[0]/Q
                          net (fo=2, unplaced)         0.136     1.416    pwm[0]/cfg[0]
                          LUT6 (Prop_lut6_I5_O)        0.098     1.514 r  pwm[0]/b[0]_i_1/O
-                         net (fo=1, unplaced)         0.000     1.514    pwm[0]/b[0]_i_1_n_0
+                         net (fo=1, unplaced)         0.000     1.514    pwm[0]/p_0_in[0]
                          FDRE                                         r  pwm[0]/b_reg[0]/D
   -------------------------------------------------------------------    -------------------
 

--- a/pyrpl/fpga/out/red_pitaya.prm
+++ b/pyrpl/fpga/out/red_pitaya.prm
@@ -1,0 +1,11 @@
+===================================
+Configuration Memory information
+===================================
+File Format        BIN
+Interface          SMAPX32
+Size               2M
+Start Address      0x00000000
+End Address        0x001FFFFF
+
+Addr1         Addr2         Date                    File(s)
+0x00000000    0x001FCB9B    Feb 19 13:35:32 2025    out/red_pitaya_uncompressed.bit

--- a/pyrpl/fpga/red_pitaya_vivado.tcl
+++ b/pyrpl/fpga/red_pitaya_vivado.tcl
@@ -44,7 +44,6 @@ source                            $path_ip/system_bd.tcl
 
 # generate SDK files
 generate_target all [get_files    system.bd]
-write_hwdef              -file    $path_sdk/red_pitaya.hwdef
 
 ################################################################################
 # read files:
@@ -56,7 +55,7 @@ write_hwdef              -file    $path_sdk/red_pitaya.hwdef
 # template
 #read_verilog                      $path_rtl/...
 
-read_verilog                      .srcs/sources_1/bd/system/hdl/system_wrapper.v
+read_verilog                      .gen/sources_1/bd/system/hdl/system_wrapper.v
 
 read_verilog                      $path_rtl/axi_master.v
 read_verilog                      $path_rtl/axi_slave.v
@@ -148,19 +147,20 @@ set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 write_bitstream -force $path_out/red_pitaya.bit
 
 ################################################################################
-# generate the .bin file for flashing via 'cat red_pitaya.bin > /dev/xdevcfg'
+# generate the .bin file for flashing
 ################################################################################
 
 set_property BITSTREAM.GENERAL.COMPRESS FALSE [current_design]
 write_bitstream -force $path_out/red_pitaya_uncompressed.bit
-write_cfgmem -force -format BIN -size 2 -interface SMAPx32 -disablebitswap -loadbit "up 0x0 $path_out/red_pitaya_uncompressed.bit" red_pitaya.bin
+write_cfgmem -force -format BIN -size 2 -interface SMAPx32 -disablebitswap -loadbit "up 0x0 $path_out/red_pitaya_uncompressed.bit" $path_out/red_pitaya.bin
 
 ################################################################################
 # generate system definition
 ################################################################################
 
-write_sysdef             -hwdef   $path_sdk/red_pitaya.hwdef \
-                         -bitfile $path_out/red_pitaya.bit \
-                         -file    $path_sdk/red_pitaya.sysdef
+write_hw_platform -include_bit -fixed -force $path_sdk/red_pitaya.xsa
+validate_hw_platform $path_sdk/red_pitaya.xsa
+
+file copy -force .gen/sources_1/bd/system/hw_handoff/system.hwh $path_sdk/red_pitaya.hwh
 
 exit

--- a/pyrpl/fpga/red_pitaya_vivado_project.tcl
+++ b/pyrpl/fpga/red_pitaya_vivado_project.tcl
@@ -38,7 +38,7 @@ generate_target all [get_files    system.bd]
 # 3. constraints
 ################################################################################
 
-read_verilog                      ./project/pyrpl.srcs/sources_1/bd/system/hdl/system_wrapper.v
+read_verilog                      ./project/pyrpl.gen/sources_1/bd/system/hdl/system_wrapper.v
 
 add_files                         $path_rtl/axi_master.v
 add_files                         $path_rtl/axi_slave.v

--- a/pyrpl/fpga/sdc/red_pitaya.xdc
+++ b/pyrpl/fpga/sdc/red_pitaya.xdc
@@ -212,6 +212,12 @@ set_input_delay -clock adc_clk 3.400 [get_ports adc_dat_b_i[*]]
 
 create_clock -period 4.000 -name rx_clk  [get_ports daisy_p_i[1]]
 
+set_property LOC XADC_X0Y0 [get_cells i_ams/XADC_inst]
+
+############################################################################
+# Clock constraints                                                        #
+############################################################################
+
 set_false_path -from [get_clocks adc_clk]     -to [get_clocks dac_clk_out]
 set_false_path -from [get_clocks clk_fpga_0]  -to [get_clocks ser_clk_out]
 set_false_path -from [get_clocks clk_fpga_0]  -to [get_clocks dac_2clk_out]
@@ -220,3 +226,10 @@ set_false_path -from [get_clocks clk_fpga_0]  -to [get_clocks par_clk]
 set_false_path -from [get_clocks dac_clk_out] -to [get_clocks dac_2clk_out]
 set_false_path -from [get_clocks dac_clk_out] -to [get_clocks dac_2ph_out]
 
+### SATA connector
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_p_o[*]}]
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_n_o[*]}]
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_p_i[*]}]
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_n_i[*]}]
+
+# set_property PULLTYPE PULLUP [get_ports daisy_p_i[1]]

--- a/pyrpl/fpga/sdc/red_pitaya_4ADC.xdc
+++ b/pyrpl/fpga/sdc/red_pitaya_4ADC.xdc
@@ -1,0 +1,203 @@
+#
+# $Id: red_pitaya_4adc.xdc 961 2014-01-21 11:40:39Z matej.oblak $
+#
+# @brief Red Pitaya location constraints.
+#
+# @Author Matej Oblak
+#
+# (c) Red Pitaya  http://www.redpitaya.com
+#
+
+############################################################################
+# IO constraints                                                           #
+############################################################################
+
+
+############################################################################
+# Clock constraints                                                        #
+############################################################################
+
+# ADC data
+set_property IOSTANDARD LVCMOS18 [get_ports {adc_dat_i[*][*]}]
+set_property IOB        TRUE     [get_ports {adc_dat_i[*][*]}]
+
+# ADC 0 data
+set_property PACKAGE_PIN Y17     [get_ports {adc_dat_i[0][0]}]
+set_property PACKAGE_PIN Y16     [get_ports {adc_dat_i[0][1]}]
+set_property PACKAGE_PIN W14     [get_ports {adc_dat_i[0][2]}]
+set_property PACKAGE_PIN Y14     [get_ports {adc_dat_i[0][3]}]
+set_property PACKAGE_PIN V12     [get_ports {adc_dat_i[0][4]}]
+set_property PACKAGE_PIN W13     [get_ports {adc_dat_i[0][5]}]
+set_property PACKAGE_PIN V13     [get_ports {adc_dat_i[0][6]}]
+
+# ADC 1 data
+set_property PACKAGE_PIN W15     [get_ports {adc_dat_i[1][0]}]
+set_property PACKAGE_PIN W16     [get_ports {adc_dat_i[1][1]}]
+set_property PACKAGE_PIN V15     [get_ports {adc_dat_i[1][2]}]
+set_property PACKAGE_PIN V16     [get_ports {adc_dat_i[1][3]}]
+set_property PACKAGE_PIN Y19     [get_ports {adc_dat_i[1][4]}]
+set_property PACKAGE_PIN W18     [get_ports {adc_dat_i[1][5]}]
+set_property PACKAGE_PIN Y18     [get_ports {adc_dat_i[1][6]}]
+
+# ADC 2 data
+set_property PACKAGE_PIN W20     [get_ports {adc_dat_i[2][0]}]
+set_property PACKAGE_PIN W19     [get_ports {adc_dat_i[2][1]}]
+set_property PACKAGE_PIN V17     [get_ports {adc_dat_i[2][2]}]
+set_property PACKAGE_PIN V18     [get_ports {adc_dat_i[2][3]}]
+set_property PACKAGE_PIN U17     [get_ports {adc_dat_i[2][4]}]
+set_property PACKAGE_PIN T16     [get_ports {adc_dat_i[2][5]}]
+set_property PACKAGE_PIN T17     [get_ports {adc_dat_i[2][6]}]
+
+# ADC 3 data
+set_property PACKAGE_PIN R19     [get_ports {adc_dat_i[3][0]}]
+set_property PACKAGE_PIN R17     [get_ports {adc_dat_i[3][1]}]
+set_property PACKAGE_PIN T15     [get_ports {adc_dat_i[3][2]}]
+set_property PACKAGE_PIN R16     [get_ports {adc_dat_i[3][3]}]
+set_property PACKAGE_PIN T20     [get_ports {adc_dat_i[3][4]}]
+set_property PACKAGE_PIN U20     [get_ports {adc_dat_i[3][5]}]
+set_property PACKAGE_PIN V20     [get_ports {adc_dat_i[3][6]}]
+
+set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {adc_clk_i[*][*]}]
+
+set_property PACKAGE_PIN U18           [get_ports {adc_clk_i[0][1]}]
+set_property PACKAGE_PIN U19           [get_ports {adc_clk_i[0][0]}]
+set_property PACKAGE_PIN N20           [get_ports {adc_clk_i[1][1]}]
+set_property PACKAGE_PIN P20           [get_ports {adc_clk_i[1][0]}]
+
+# Output ADC clock
+# set_property IOSTANDARD LVCMOS18 [get_ports {adc_clk_o[*]}]
+# set_property SLEW       FAST     [get_ports {adc_clk_o[*]}]
+# set_property DRIVE      8        [get_ports {adc_clk_o[*]}]
+# #set_property IOB        TRUE     [get_ports {adc_clk_o[*]}]
+
+# set_property PACKAGE_PIN N20 [get_ports {adc_clk_o[0]}]
+# set_property PACKAGE_PIN P20 [get_ports {adc_clk_o[1]}]
+
+# SPI interface
+set_property IOSTANDARD  LVCMOS18 [get_ports spi_*_o]
+set_property SLEW        FAST     [get_ports spi_*_o]
+set_property DRIVE       8        [get_ports spi_*_o]
+
+set_property PACKAGE_PIN P15      [get_ports spi_csa_o]
+set_property PACKAGE_PIN P16      [get_ports spi_csb_o]
+set_property PACKAGE_PIN P18      [get_ports spi_clk_o]
+set_property PACKAGE_PIN N17      [get_ports spi_mosi_o]
+
+### PWM DAC
+set_property IOSTANDARD LVCMOS18 [get_ports {dac_pwm_o[*]}]
+set_property SLEW FAST           [get_ports {dac_pwm_o[*]}]
+set_property DRIVE 12            [get_ports {dac_pwm_o[*]}]
+set_property IOB TRUE            [get_ports {dac_pwm_o[*]}]
+
+set_property PACKAGE_PIN T10 [get_ports {dac_pwm_o[0]}]
+set_property PACKAGE_PIN T11 [get_ports {dac_pwm_o[1]}]
+set_property PACKAGE_PIN T19 [get_ports {dac_pwm_o[2]}]
+set_property PACKAGE_PIN T14 [get_ports {dac_pwm_o[3]}]
+
+### XADC
+set_property IOSTANDARD LVCMOS33 [get_ports {vinp_i[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {vinn_i[*]}]
+#AD0
+set_property PACKAGE_PIN C20 [get_ports {vinp_i[1]}]
+set_property PACKAGE_PIN B20 [get_ports {vinn_i[1]}]
+#AD1
+set_property PACKAGE_PIN E17 [get_ports {vinp_i[2]}]
+set_property PACKAGE_PIN D18 [get_ports {vinn_i[2]}]
+#AD8
+set_property PACKAGE_PIN B19 [get_ports {vinp_i[0]}]
+set_property PACKAGE_PIN A20 [get_ports {vinn_i[0]}]
+#AD9
+set_property PACKAGE_PIN E18 [get_ports {vinp_i[3]}]
+set_property PACKAGE_PIN E19 [get_ports {vinn_i[3]}]
+#V_0
+set_property PACKAGE_PIN K9  [get_ports {vinp_i[4]}]
+set_property PACKAGE_PIN L10 [get_ports {vinn_i[4]}]
+
+### Expansion connector
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_p_io[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_n_io[*]}]
+set_property SLEW       FAST     [get_ports {exp_p_io[*]}]
+set_property SLEW       FAST     [get_ports {exp_n_io[*]}]
+set_property DRIVE      8        [get_ports {exp_p_io[*]}]
+set_property DRIVE      8        [get_ports {exp_n_io[*]}]
+
+set_property PACKAGE_PIN G17 [get_ports {exp_p_io[0]}]
+set_property PACKAGE_PIN G18 [get_ports {exp_n_io[0]}]
+set_property PACKAGE_PIN H16 [get_ports {exp_p_io[1]}]
+set_property PACKAGE_PIN H17 [get_ports {exp_n_io[1]}]
+set_property PACKAGE_PIN J18 [get_ports {exp_p_io[2]}]
+set_property PACKAGE_PIN H18 [get_ports {exp_n_io[2]}]
+set_property PACKAGE_PIN K17 [get_ports {exp_p_io[3]}]
+set_property PACKAGE_PIN K18 [get_ports {exp_n_io[3]}]
+set_property PACKAGE_PIN L14 [get_ports {exp_p_io[4]}]
+set_property PACKAGE_PIN L15 [get_ports {exp_n_io[4]}]
+set_property PACKAGE_PIN L16 [get_ports {exp_p_io[5]}]
+set_property PACKAGE_PIN L17 [get_ports {exp_n_io[5]}]
+set_property PACKAGE_PIN K16 [get_ports {exp_p_io[6]}]
+set_property PACKAGE_PIN J16 [get_ports {exp_n_io[6]}]
+set_property PACKAGE_PIN M14 [get_ports {exp_p_io[7]}]
+set_property PACKAGE_PIN M15 [get_ports {exp_n_io[7]}]
+set_property PACKAGE_PIN Y9  [get_ports {exp_p_io[8]}]
+set_property PACKAGE_PIN Y8  [get_ports {exp_n_io[8]}]
+set_property PACKAGE_PIN Y12 [get_ports {exp_p_io[9]}]
+set_property PACKAGE_PIN Y13 [get_ports {exp_n_io[9]}]
+set_property PACKAGE_PIN Y7  [get_ports {exp_p_io[10]}]
+set_property PACKAGE_PIN Y6  [get_ports {exp_n_io[10]}]
+
+### PLL
+set_property IOSTANDARD LVCMOS33 [get_ports pll_*]
+set_property PACKAGE_PIN J15 [get_ports pll_hi_o]
+set_property PACKAGE_PIN K14 [get_ports pll_lo_o]
+
+### SATA connector
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_p_o[*]}]
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_n_o[*]}]
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_p_i[*]}]
+# set_property IOSTANDARD DIFF_HSTL_I_18 [get_ports {daisy_n_i[*]}]
+
+set_property PACKAGE_PIN T12 [get_ports {daisy_p_o[0]}]
+set_property PACKAGE_PIN U12 [get_ports {daisy_n_o[0]}]
+set_property PACKAGE_PIN U14 [get_ports {daisy_p_o[1]}]
+set_property PACKAGE_PIN U15 [get_ports {daisy_n_o[1]}]
+set_property PACKAGE_PIN P14 [get_ports {daisy_p_i[0]}]
+set_property PACKAGE_PIN R14 [get_ports {daisy_n_i[0]}]
+set_property PACKAGE_PIN N18 [get_ports {daisy_p_i[1]}]
+set_property PACKAGE_PIN P19 [get_ports {daisy_n_i[1]}]
+
+### LED
+set_property IOSTANDARD LVCMOS33 [get_ports {led_o[*]}]
+set_property SLEW       SLOW     [get_ports {led_o[*]}]
+set_property DRIVE      4        [get_ports {led_o[*]}]
+
+set_property PACKAGE_PIN F16     [get_ports {led_o[0]}]
+set_property PACKAGE_PIN F17     [get_ports {led_o[1]}]
+set_property PACKAGE_PIN G19     [get_ports {led_o[2]}]
+set_property PACKAGE_PIN G15     [get_ports {led_o[3]}]
+set_property PACKAGE_PIN G14     [get_ports {led_o[4]}]
+set_property PACKAGE_PIN F20     [get_ports {led_o[5]}]
+set_property PACKAGE_PIN G20     [get_ports {led_o[6]}]
+set_property PACKAGE_PIN H20     [get_ports {led_o[7]}]
+
+############################################################################
+# Clock constraints                                                        #
+############################################################################
+
+#NET "adc_clk" TNM_NET = "adc_clk";
+#TIMESPEC TS_adc_clk = PERIOD "adc_clk" 125 MHz;
+
+
+create_clock -period 8.000 -name adc_clk_01 [get_ports {adc_clk_i[0][1]}]
+create_clock -period 8.000 -name adc_clk_23 [get_ports {adc_clk_i[1][1]}]
+create_clock -period 4.000 -name rx_clk [get_ports {daisy_p_i[1]}]
+
+set_false_path -from [get_clocks par_clk] -to [get_clocks pll_adc_clk_0]
+set_false_path -from [get_clocks pll_adc_clk_0] -to [get_clocks par_clk]
+set_false_path -from [get_clocks clk_fpga_0] -to [get_clocks adc_clk_01]
+set_false_path -from [get_clocks clk_fpga_0] -to [get_clocks adc_clk_23]
+set_false_path -from [get_clocks adc_clk_01] -to [get_clocks pll_ser_clk]
+set_false_path -from [get_clocks clk_fpga_0] -to [get_clocks par_clk]
+set_false_path -from [get_clocks clk_fpga_0] -to [get_clocks pll_adc_clk_0]
+set_false_path -from [get_clocks pll_adc_clk_0] -to [get_clocks clk_fpga_0]
+set_false_path -from [get_clocks pll_adc_clk_0] -to [get_clocks pll_adc_10mhz]
+set_false_path -from [get_clocks pll_adc_10mhz] -to [get_clocks pll_adc_clk_0]
+set_false_path -from [get_clocks adc_clk_23] -to [get_clocks pll_adc_clk_0]

--- a/pyrpl/fpga/sdc_250/red_pitaya.xdc
+++ b/pyrpl/fpga/sdc_250/red_pitaya.xdc
@@ -1,0 +1,297 @@
+#
+# $Id: red_pitaya.xdc 961 2014-01-21 11:40:39Z matej.oblak $
+#
+# @brief Red Pitaya location constraints.
+#
+# @Author Matej Oblak
+#
+# (c) Red Pitaya  http://www.redpitaya.com
+#
+
+############################################################################
+# IO constraints                                                           #
+############################################################################
+
+### ADC
+
+# ADC data
+set_property IOSTANDARD DIFF_SSTL18_II [get_ports {adc_dat_?_i[*][*]}]
+set_property IOB TRUE [get_ports {adc_dat_?_i[*][*]}]
+#set_property DIFF_TERM TRUE [get_ports {adc_dat_?_i[*][*]}]
+
+# ADC 0 data
+set_property PACKAGE_PIN W18 [get_ports {adc_dat_p_i[0][0]}] ; # ADAxP
+set_property PACKAGE_PIN W19 [get_ports {adc_dat_n_i[0][0]}] ; # ADAxN
+set_property PACKAGE_PIN Y16 [get_ports {adc_dat_p_i[0][1]}] ; # ADA0P
+set_property PACKAGE_PIN Y17 [get_ports {adc_dat_n_i[0][1]}] ; # ADA0N
+set_property PACKAGE_PIN V12 [get_ports {adc_dat_p_i[0][2]}] ; # ADA2P
+set_property PACKAGE_PIN W13 [get_ports {adc_dat_n_i[0][2]}] ; # ADA2N
+set_property PACKAGE_PIN T11 [get_ports {adc_dat_p_i[0][3]}] ; # ADA4P
+set_property PACKAGE_PIN T10 [get_ports {adc_dat_n_i[0][3]}] ; # ADA4N
+set_property PACKAGE_PIN W14 [get_ports {adc_dat_p_i[0][4]}] ; # ADA6P
+set_property PACKAGE_PIN Y14 [get_ports {adc_dat_n_i[0][4]}] ; # ADA6N
+set_property PACKAGE_PIN V16 [get_ports {adc_dat_p_i[0][5]}] ; # ADA8P
+set_property PACKAGE_PIN W16 [get_ports {adc_dat_n_i[0][5]}] ; # ADA8N
+set_property PACKAGE_PIN T20 [get_ports {adc_dat_p_i[0][6]}] ; # ADA10P
+set_property PACKAGE_PIN U20 [get_ports {adc_dat_n_i[0][6]}] ; # ADA10N
+
+# ADC 1 data
+set_property PACKAGE_PIN N17 [get_ports {adc_dat_p_i[1][0]}] ; # ADBxP
+set_property PACKAGE_PIN P18 [get_ports {adc_dat_n_i[1][0]}] ; # ADBxN
+set_property PACKAGE_PIN T17 [get_ports {adc_dat_p_i[1][1]}] ; # ADB0P
+set_property PACKAGE_PIN R18 [get_ports {adc_dat_n_i[1][1]}] ; # ADB0N
+set_property PACKAGE_PIN T16 [get_ports {adc_dat_p_i[1][2]}] ; # ADB2P
+set_property PACKAGE_PIN U17 [get_ports {adc_dat_n_i[1][2]}] ; # ADB2N
+set_property PACKAGE_PIN V20 [get_ports {adc_dat_p_i[1][3]}] ; # ADB4P
+set_property PACKAGE_PIN W20 [get_ports {adc_dat_n_i[1][3]}] ; # ADB4N
+set_property PACKAGE_PIN Y18 [get_ports {adc_dat_p_i[1][4]}] ; # ADB6P
+set_property PACKAGE_PIN Y19 [get_ports {adc_dat_n_i[1][4]}] ; # ADB6N
+set_property PACKAGE_PIN T14 [get_ports {adc_dat_p_i[1][5]}] ; # ADB8P
+set_property PACKAGE_PIN T15 [get_ports {adc_dat_n_i[1][5]}] ; # ADB8N
+set_property PACKAGE_PIN V15 [get_ports {adc_dat_p_i[1][6]}] ; # ADB10P
+set_property PACKAGE_PIN W15 [get_ports {adc_dat_n_i[1][6]}] ; # ADB10N
+
+
+set_property IOSTANDARD DIFF_SSTL18_II [get_ports {adc_clk_i[*]}]
+#set_property DIFF_TERM TRUE [get_ports {adc_clk_i[*]}]
+set_property PACKAGE_PIN U18 [get_ports {adc_clk_i[1]}] ; # ADCLKP
+set_property PACKAGE_PIN U19 [get_ports {adc_clk_i[0]}] ; # ADCLKN
+
+# ADC SPI
+set_property IOSTANDARD LVCMOS18 [get_ports adc_spi_*]
+set_property SLEW SLOW [get_ports adc_spi_*]
+set_property DRIVE 8 [get_ports adc_spi_*]
+set_property PACKAGE_PIN U13 [get_ports adc_spi_csb]
+set_property PACKAGE_PIN V18 [get_ports adc_spi_sdio]
+set_property PACKAGE_PIN V13 [get_ports adc_spi_clk]
+
+# ADC SYNC
+set_property IOSTANDARD LVCMOS18 [get_ports adc_sync_o]
+set_property SLEW SLOW [get_ports adc_sync_o]
+set_property DRIVE 8 [get_ports adc_sync_o]
+set_property PACKAGE_PIN P15 [get_ports adc_sync_o]
+
+
+
+
+### DAC
+
+set_property IOSTANDARD LVCMOS33 [get_ports dac_dco_i]
+set_property PACKAGE_PIN L16 [get_ports dac_dco_i]
+
+set_property IOSTANDARD LVCMOS33 [get_ports dac_reset_o]
+set_property PACKAGE_PIN F16 [get_ports dac_reset_o]
+
+# data
+set_property IOSTANDARD LVCMOS33 [get_ports {dac_dat_o[*][*]}]
+set_property SLEW FAST [get_ports {dac_dat_o[*][*]}]
+set_property DRIVE 8 [get_ports {dac_dat_o[*][*]}]
+set_property IOB TRUE [get_ports {dac_dat_o[*]}]
+
+set_property PACKAGE_PIN L19 [get_ports {dac_dat_o[0][0]}]
+set_property PACKAGE_PIN L20 [get_ports {dac_dat_o[0][1]}]
+set_property PACKAGE_PIN K19 [get_ports {dac_dat_o[0][2]}]
+set_property PACKAGE_PIN J19 [get_ports {dac_dat_o[0][3]}]
+set_property PACKAGE_PIN J20 [get_ports {dac_dat_o[0][4]}]
+set_property PACKAGE_PIN J18 [get_ports {dac_dat_o[0][5]}]
+set_property PACKAGE_PIN H20 [get_ports {dac_dat_o[0][6]}]
+set_property PACKAGE_PIN G19 [get_ports {dac_dat_o[0][7]}]
+set_property PACKAGE_PIN G20 [get_ports {dac_dat_o[0][8]}]
+set_property PACKAGE_PIN F17 [get_ports {dac_dat_o[0][9]}]
+set_property PACKAGE_PIN F20 [get_ports {dac_dat_o[0][10]}]
+set_property PACKAGE_PIN F19 [get_ports {dac_dat_o[0][11]}]
+set_property PACKAGE_PIN D20 [get_ports {dac_dat_o[0][12]}]
+set_property PACKAGE_PIN D19 [get_ports {dac_dat_o[0][13]}]
+
+set_property PACKAGE_PIN G18 [get_ports {dac_dat_o[1][0]}]
+set_property PACKAGE_PIN G17 [get_ports {dac_dat_o[1][1]}]
+set_property PACKAGE_PIN H17 [get_ports {dac_dat_o[1][2]}]
+set_property PACKAGE_PIN H18 [get_ports {dac_dat_o[1][3]}]
+set_property PACKAGE_PIN J16 [get_ports {dac_dat_o[1][4]}]
+set_property PACKAGE_PIN K16 [get_ports {dac_dat_o[1][5]}]
+set_property PACKAGE_PIN K17 [get_ports {dac_dat_o[1][6]}]
+set_property PACKAGE_PIN L15 [get_ports {dac_dat_o[1][7]}]
+set_property PACKAGE_PIN M20 [get_ports {dac_dat_o[1][8]}]
+set_property PACKAGE_PIN M19 [get_ports {dac_dat_o[1][9]}]
+set_property PACKAGE_PIN M17 [get_ports {dac_dat_o[1][10]}]
+set_property PACKAGE_PIN M18 [get_ports {dac_dat_o[1][11]}]
+set_property PACKAGE_PIN L17 [get_ports {dac_dat_o[1][12]}]
+set_property PACKAGE_PIN K18 [get_ports {dac_dat_o[1][13]}]
+
+# DAC SPI
+set_property IOSTANDARD LVCMOS33 [get_ports dac_spi_*]
+set_property SLEW SLOW [get_ports dac_spi_*]
+set_property DRIVE 8 [get_ports dac_spi_*]
+set_property PACKAGE_PIN G14 [get_ports dac_spi_csb]
+set_property PACKAGE_PIN H16 [get_ports dac_spi_sdio]
+set_property PACKAGE_PIN G15 [get_ports dac_spi_clk]
+
+
+### PWM DAC
+set_property IOSTANDARD LVCMOS18 [get_ports {dac_pwm_o[*]}]
+set_property SLEW FAST [get_ports {dac_pwm_o[*]}]
+set_property DRIVE 12 [get_ports {dac_pwm_o[*]}]
+set_property IOB TRUE [get_ports {dac_pwm_o[*]}]
+
+set_property PACKAGE_PIN P20 [get_ports {dac_pwm_o[0]}]
+set_property PACKAGE_PIN P16 [get_ports {dac_pwm_o[1]}]
+set_property PACKAGE_PIN R17 [get_ports {dac_pwm_o[2]}]
+set_property PACKAGE_PIN R19 [get_ports {dac_pwm_o[3]}]
+
+### XADC
+set_property IOSTANDARD LVCMOS33 [get_ports {vinp_i[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {vinn_i[*]}]
+#AD0
+#AD1
+#AD8
+#AD9
+#V_0
+set_property PACKAGE_PIN E18 [get_ports {vinp_i[3]}]
+set_property PACKAGE_PIN E19 [get_ports {vinn_i[3]}]
+set_property PACKAGE_PIN E17 [get_ports {vinp_i[2]}]
+set_property PACKAGE_PIN D18 [get_ports {vinn_i[2]}]
+set_property PACKAGE_PIN C20 [get_ports {vinp_i[1]}]
+set_property PACKAGE_PIN B20 [get_ports {vinn_i[1]}]
+set_property PACKAGE_PIN L10 [get_ports {vinn_i[4]}]
+set_property PACKAGE_PIN B19 [get_ports {vinp_i[0]}]
+set_property PACKAGE_PIN A20 [get_ports {vinn_i[0]}]
+set_property PACKAGE_PIN K9 [get_ports {vinp_i[4]}]
+
+### Trigger
+set_property IOSTANDARD LVCMOS18 [get_ports trig_i]
+set_property PACKAGE_PIN N20 [get_ports trig_i]
+
+### PLL
+set_property IOSTANDARD LVCMOS33 [get_ports pll_*]
+set_property PACKAGE_PIN U7 [get_ports pll_ref_i]
+set_property PACKAGE_PIN V6 [get_ports pll_hi_o]
+set_property PACKAGE_PIN V5 [get_ports pll_lo_o]
+
+### Temperature protection
+set_property IOSTANDARD LVCMOS33 [get_ports {temp_prot_i[*]}]
+set_property PACKAGE_PIN W6 [get_ports {temp_prot_i[0]}]
+set_property PACKAGE_PIN V7 [get_ports {temp_prot_i[1]}]
+
+
+### Expansion connector
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_p_io[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_n_io[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_9_io}]
+set_property SLEW FAST [get_ports {exp_p_io[*]}]
+set_property SLEW FAST [get_ports {exp_n_io[*]}]
+set_property SLEW FAST [get_ports {exp_9_io}]
+set_property DRIVE 8 [get_ports {exp_p_io[*]}]
+set_property DRIVE 8 [get_ports {exp_n_io[*]}]
+set_property DRIVE 8 [get_ports {exp_9_io}]
+
+set_property PACKAGE_PIN W10 [get_ports {exp_p_io[0]}]
+set_property PACKAGE_PIN W9 [get_ports {exp_n_io[0]}]
+set_property PACKAGE_PIN T9 [get_ports {exp_p_io[1]}]
+set_property PACKAGE_PIN U10 [get_ports {exp_n_io[1]}]
+set_property PACKAGE_PIN Y9 [get_ports {exp_p_io[2]}]
+set_property PACKAGE_PIN Y8 [get_ports {exp_n_io[2]}]
+set_property PACKAGE_PIN U9 [get_ports {exp_p_io[3]}]
+set_property PACKAGE_PIN U8 [get_ports {exp_n_io[3]}]
+set_property PACKAGE_PIN V8 [get_ports {exp_p_io[4]}]
+set_property PACKAGE_PIN W8 [get_ports {exp_n_io[4]}]
+set_property PACKAGE_PIN V11 [get_ports {exp_p_io[5]}]
+set_property PACKAGE_PIN V10 [get_ports {exp_n_io[5]}]
+set_property PACKAGE_PIN W11 [get_ports {exp_p_io[6]}]
+set_property PACKAGE_PIN Y11 [get_ports {exp_n_io[6]}]
+set_property PACKAGE_PIN Y12 [get_ports {exp_p_io[7]}]
+set_property PACKAGE_PIN Y13 [get_ports {exp_n_io[7]}]
+set_property PACKAGE_PIN Y7  [get_ports {exp_p_io[8]}]
+set_property PACKAGE_PIN Y6  [get_ports {exp_n_io[8]}]
+set_property PACKAGE_PIN U5  [get_ports {exp_9_io}]
+
+#set_property PULLDOWN TRUE [get_ports {exp_p_io[0]}]
+#set_property PULLDOWN TRUE [get_ports {exp_n_io[0]}]
+#set_property PULLUP   TRUE [get_ports {exp_p_io[7]}]
+#set_property PULLUP   TRUE [get_ports {exp_n_io[7]}]
+
+### SATA connector
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_p_o[*]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_n_o[*]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_p_i[*]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_n_i[*]}]
+
+set_property PACKAGE_PIN T12 [get_ports {daisy_p_o[0]}]
+set_property PACKAGE_PIN U12 [get_ports {daisy_n_o[0]}]
+set_property PACKAGE_PIN U14 [get_ports {daisy_p_o[1]}]
+set_property PACKAGE_PIN U15 [get_ports {daisy_n_o[1]}]
+set_property PACKAGE_PIN P14 [get_ports {daisy_p_i[0]}]
+set_property PACKAGE_PIN R14 [get_ports {daisy_n_i[0]}]
+set_property PACKAGE_PIN N18 [get_ports {daisy_p_i[1]}]
+set_property PACKAGE_PIN P19 [get_ports {daisy_n_i[1]}]
+
+### LED
+set_property IOSTANDARD LVCMOS33 [get_ports {led_o[*]}]
+set_property SLEW SLOW [get_ports {led_o[*]}]
+set_property DRIVE 4 [get_ports {led_o[*]}]
+
+set_property PACKAGE_PIN K14 [get_ports {led_o[0]}]
+set_property PACKAGE_PIN J15 [get_ports {led_o[1]}]
+set_property PACKAGE_PIN J14 [get_ports {led_o[2]}]
+set_property PACKAGE_PIN H15 [get_ports {led_o[3]}]
+set_property PACKAGE_PIN L14 [get_ports {led_o[4]}]
+set_property PACKAGE_PIN M14 [get_ports {led_o[5]}]
+set_property PACKAGE_PIN M15 [get_ports {led_o[6]}]
+set_property PACKAGE_PIN N15 [get_ports {led_o[7]}]
+
+
+############################################################################
+# Clock constraints                                                        #
+############################################################################
+
+create_clock -period 4.000 -name adc_clk [get_ports {adc_clk_i[1]}]
+create_clock -period 4.000 -name dco_clk [get_ports dac_dco_i]
+create_clock -period 100.000 -name pll_ref_i -waveform {0.000 50.000} [get_ports pll_ref_i]
+create_clock -period 4.000 -name rx_clk [get_ports {daisy_p_i[1]}]
+
+create_generated_clock -name i_hk/dna_clk -source [get_pins pll/pll/CLKOUT1] -divide_by 8 [get_pins i_hk/dna_clk_reg/Q]
+
+set_clock_groups -asynchronous -group pll_adc_clk -group clk_fpga_0 -group pll_adc_clk2d -group adc_clk
+set_clock_groups -asynchronous -group pll_adc_clk2d -group i_hk/dna_clk -group par_clk -group pll_pwm_clk -group pll_ref_i
+
+# set_false_path -from [get_clocks clk_fpga_0]    -to [get_clocks pll_adc_clk]
+# set_false_path -from [get_clocks pll_adc_clk]   -to [get_clocks clk_fpga_0]
+
+# set_false_path -from [get_clocks pll_adc_clk2d] -to [get_clocks pll_adc_clk]
+# set_false_path -from [get_clocks pll_adc_clk]   -to [get_clocks pll_adc_clk2d]
+
+# set_false_path -from [get_clocks pll_adc_clk2d] -to [get_clocks pll_pwm_clk]
+# set_false_path -from [get_clocks pll_adc_10mhz] -to [get_clocks pll_adc_clk2d]
+# set_false_path -from [get_clocks pll_adc_clk2d] -to [get_clocks pll_adc_10mhz]
+
+# set_false_path -from [get_clocks pll_adc_clk2d] -to [get_clocks par_clk]
+# set_false_path -from [get_clocks pll_adc_10mhz] -to [get_clocks pll_ref_i]
+
+# set_false_path -from [get_clocks par_clk]   -to [get_clocks pll_adc_clk2d]
+# set_false_path -from [get_clocks pll_ref_i] -to [get_clocks pll_adc_10mhz]
+
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_p_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_p_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_p_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_p_i[1][*]}]
+
+
+
+
+
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+
+

--- a/pyrpl/fpga/sdc_250/red_pitaya_v1r0.xdc
+++ b/pyrpl/fpga/sdc_250/red_pitaya_v1r0.xdc
@@ -1,0 +1,296 @@
+#
+# $Id: red_pitaya.xdc 961 2014-01-21 11:40:39Z matej.oblak $
+#
+# @brief Red Pitaya location constraints.
+#
+# @Author Matej Oblak
+#
+# (c) Red Pitaya  http://www.redpitaya.com
+#
+
+############################################################################
+# IO constraints                                                           #
+############################################################################
+
+### ADC
+
+# ADC data
+set_property IOSTANDARD DIFF_SSTL18_II [get_ports {adc_dat_?_i[*][*]}]
+set_property IOB TRUE [get_ports {adc_dat_?_i[*][*]}]
+#set_property DIFF_TERM TRUE [get_ports {adc_dat_?_i[*][*]}]
+
+# ADC 0 data
+set_property PACKAGE_PIN W18 [get_ports {adc_dat_p_i[0][0]}] ; # ADAxP
+set_property PACKAGE_PIN W19 [get_ports {adc_dat_n_i[0][0]}] ; # ADAxN
+set_property PACKAGE_PIN U13 [get_ports {adc_dat_p_i[0][1]}] ; # ADA0P
+set_property PACKAGE_PIN V13 [get_ports {adc_dat_n_i[0][1]}] ; # ADA0N
+set_property PACKAGE_PIN Y16 [get_ports {adc_dat_p_i[0][2]}] ; # ADA2P
+set_property PACKAGE_PIN Y17 [get_ports {adc_dat_n_i[0][2]}] ; # ADA2N
+set_property PACKAGE_PIN V12 [get_ports {adc_dat_p_i[0][3]}] ; # ADA4P
+set_property PACKAGE_PIN W13 [get_ports {adc_dat_n_i[0][3]}] ; # ADA4N
+set_property PACKAGE_PIN T11 [get_ports {adc_dat_p_i[0][4]}] ; # ADA6P
+set_property PACKAGE_PIN T10 [get_ports {adc_dat_n_i[0][4]}] ; # ADA6N
+set_property PACKAGE_PIN V16 [get_ports {adc_dat_p_i[0][5]}] ; # ADA8P
+set_property PACKAGE_PIN W16 [get_ports {adc_dat_n_i[0][5]}] ; # ADA8N
+set_property PACKAGE_PIN T20 [get_ports {adc_dat_p_i[0][6]}] ; # ADA10P
+set_property PACKAGE_PIN U20 [get_ports {adc_dat_n_i[0][6]}] ; # ADA10N
+
+# ADC 1 data
+set_property PACKAGE_PIN N17 [get_ports {adc_dat_p_i[1][0]}] ; # ADBxP
+set_property PACKAGE_PIN P18 [get_ports {adc_dat_n_i[1][0]}] ; # ADBxN
+set_property PACKAGE_PIN T17 [get_ports {adc_dat_p_i[1][1]}] ; # ADB0P
+set_property PACKAGE_PIN R18 [get_ports {adc_dat_n_i[1][1]}] ; # ADB0N
+set_property PACKAGE_PIN T16 [get_ports {adc_dat_p_i[1][2]}] ; # ADB2P
+set_property PACKAGE_PIN U17 [get_ports {adc_dat_n_i[1][2]}] ; # ADB2N
+set_property PACKAGE_PIN V20 [get_ports {adc_dat_p_i[1][3]}] ; # ADB4P
+set_property PACKAGE_PIN W20 [get_ports {adc_dat_n_i[1][3]}] ; # ADB4N
+set_property PACKAGE_PIN Y18 [get_ports {adc_dat_p_i[1][4]}] ; # ADB6P
+set_property PACKAGE_PIN Y19 [get_ports {adc_dat_n_i[1][4]}] ; # ADB6N
+set_property PACKAGE_PIN T14 [get_ports {adc_dat_p_i[1][5]}] ; # ADB8P
+set_property PACKAGE_PIN T15 [get_ports {adc_dat_n_i[1][5]}] ; # ADB8N
+set_property PACKAGE_PIN V15 [get_ports {adc_dat_p_i[1][6]}] ; # ADB10P
+set_property PACKAGE_PIN W15 [get_ports {adc_dat_n_i[1][6]}] ; # ADB10N
+
+
+set_property IOSTANDARD DIFF_SSTL18_II [get_ports {adc_clk_i[*]}]
+#set_property DIFF_TERM TRUE [get_ports {adc_clk_i[*]}]
+set_property PACKAGE_PIN U18 [get_ports {adc_clk_i[1]}] ; # ADCLKP
+set_property PACKAGE_PIN U19 [get_ports {adc_clk_i[0]}] ; # ADCLKN
+
+# ADC SPI
+set_property IOSTANDARD LVCMOS18 [get_ports adc_spi_*]
+set_property SLEW SLOW [get_ports adc_spi_*]
+set_property DRIVE 8 [get_ports adc_spi_*]
+set_property PACKAGE_PIN Y14 [get_ports adc_spi_csb]
+set_property PACKAGE_PIN V18 [get_ports adc_spi_sdio]
+set_property PACKAGE_PIN W14 [get_ports adc_spi_clk]
+
+# ADC SYNC
+set_property IOSTANDARD LVCMOS18 [get_ports adc_sync_o]
+set_property SLEW SLOW [get_ports adc_sync_o]
+set_property DRIVE 8 [get_ports adc_sync_o]
+set_property PACKAGE_PIN P15 [get_ports adc_sync_o]
+
+
+
+
+### DAC
+
+set_property IOSTANDARD LVCMOS33 [get_ports dac_dco_i]
+set_property PACKAGE_PIN L16 [get_ports dac_dco_i]
+
+set_property IOSTANDARD LVCMOS33 [get_ports dac_reset_o]
+set_property PACKAGE_PIN F16 [get_ports dac_reset_o]
+
+# data
+set_property IOSTANDARD LVCMOS33 [get_ports {dac_dat_o[*][*]}]
+set_property SLEW FAST [get_ports {dac_dat_o[*][*]}]
+set_property DRIVE 8 [get_ports {dac_dat_o[*][*]}]
+set_property IOB TRUE [get_ports {dac_dat_o[*]}]
+
+set_property PACKAGE_PIN L19 [get_ports {dac_dat_o[0][0]}]
+set_property PACKAGE_PIN L20 [get_ports {dac_dat_o[0][1]}]
+set_property PACKAGE_PIN K19 [get_ports {dac_dat_o[0][2]}]
+set_property PACKAGE_PIN J19 [get_ports {dac_dat_o[0][3]}]
+set_property PACKAGE_PIN J20 [get_ports {dac_dat_o[0][4]}]
+set_property PACKAGE_PIN J18 [get_ports {dac_dat_o[0][5]}]
+set_property PACKAGE_PIN H20 [get_ports {dac_dat_o[0][6]}]
+set_property PACKAGE_PIN G19 [get_ports {dac_dat_o[0][7]}]
+set_property PACKAGE_PIN G20 [get_ports {dac_dat_o[0][8]}]
+set_property PACKAGE_PIN F17 [get_ports {dac_dat_o[0][9]}]
+set_property PACKAGE_PIN F20 [get_ports {dac_dat_o[0][10]}]
+set_property PACKAGE_PIN F19 [get_ports {dac_dat_o[0][11]}]
+set_property PACKAGE_PIN D20 [get_ports {dac_dat_o[0][12]}]
+set_property PACKAGE_PIN D19 [get_ports {dac_dat_o[0][13]}]
+
+set_property PACKAGE_PIN G18 [get_ports {dac_dat_o[1][0]}]
+set_property PACKAGE_PIN G17 [get_ports {dac_dat_o[1][1]}]
+set_property PACKAGE_PIN H17 [get_ports {dac_dat_o[1][2]}]
+set_property PACKAGE_PIN H18 [get_ports {dac_dat_o[1][3]}]
+set_property PACKAGE_PIN J16 [get_ports {dac_dat_o[1][4]}]
+set_property PACKAGE_PIN K16 [get_ports {dac_dat_o[1][5]}]
+set_property PACKAGE_PIN K17 [get_ports {dac_dat_o[1][6]}]
+set_property PACKAGE_PIN L15 [get_ports {dac_dat_o[1][7]}]
+set_property PACKAGE_PIN M20 [get_ports {dac_dat_o[1][8]}]
+set_property PACKAGE_PIN M19 [get_ports {dac_dat_o[1][9]}]
+set_property PACKAGE_PIN M17 [get_ports {dac_dat_o[1][10]}]
+set_property PACKAGE_PIN M18 [get_ports {dac_dat_o[1][11]}]
+set_property PACKAGE_PIN L17 [get_ports {dac_dat_o[1][12]}]
+set_property PACKAGE_PIN K18 [get_ports {dac_dat_o[1][13]}]
+
+# DAC SPI
+set_property IOSTANDARD LVCMOS33 [get_ports dac_spi_*]
+set_property SLEW SLOW [get_ports dac_spi_*]
+set_property DRIVE 8 [get_ports dac_spi_*]
+set_property PACKAGE_PIN G14 [get_ports dac_spi_csb]
+set_property PACKAGE_PIN H16 [get_ports dac_spi_sdio]
+set_property PACKAGE_PIN G15 [get_ports dac_spi_clk]
+
+
+### PWM DAC
+set_property IOSTANDARD LVCMOS18 [get_ports {dac_pwm_o[*]}]
+set_property SLEW FAST [get_ports {dac_pwm_o[*]}]
+set_property DRIVE 12 [get_ports {dac_pwm_o[*]}]
+set_property IOB TRUE [get_ports {dac_pwm_o[*]}]
+
+set_property PACKAGE_PIN P20 [get_ports {dac_pwm_o[0]}]
+set_property PACKAGE_PIN P16 [get_ports {dac_pwm_o[1]}]
+set_property PACKAGE_PIN R17 [get_ports {dac_pwm_o[2]}]
+set_property PACKAGE_PIN R19 [get_ports {dac_pwm_o[3]}]
+
+### XADC
+set_property IOSTANDARD LVCMOS33 [get_ports {vinp_i[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {vinn_i[*]}]
+#AD0
+#AD1
+#AD8
+#AD9
+#V_0
+set_property PACKAGE_PIN E18 [get_ports {vinp_i[3]}]
+set_property PACKAGE_PIN E19 [get_ports {vinn_i[3]}]
+set_property PACKAGE_PIN E17 [get_ports {vinp_i[2]}]
+set_property PACKAGE_PIN D18 [get_ports {vinn_i[2]}]
+set_property PACKAGE_PIN C20 [get_ports {vinp_i[1]}]
+set_property PACKAGE_PIN B20 [get_ports {vinn_i[1]}]
+set_property PACKAGE_PIN L10 [get_ports {vinn_i[4]}]
+set_property PACKAGE_PIN B19 [get_ports {vinp_i[0]}]
+set_property PACKAGE_PIN A20 [get_ports {vinn_i[0]}]
+set_property PACKAGE_PIN K9 [get_ports {vinp_i[4]}]
+
+### Trigger
+set_property IOSTANDARD LVCMOS18 [get_ports trig_i]
+set_property PACKAGE_PIN N20 [get_ports trig_i]
+
+### PLL
+set_property IOSTANDARD LVCMOS33 [get_ports pll_*]
+set_property PACKAGE_PIN U7 [get_ports pll_ref_i]
+set_property PACKAGE_PIN V6 [get_ports pll_hi_o]
+set_property PACKAGE_PIN V5 [get_ports pll_lo_o]
+
+### Temperature protection
+set_property IOSTANDARD LVCMOS33 [get_ports {temp_prot_i[*]}]
+set_property PACKAGE_PIN W6 [get_ports {temp_prot_i[0]}]
+set_property PACKAGE_PIN V7 [get_ports {temp_prot_i[1]}]
+
+
+### Expansion connector
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_p_io[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_n_io[*]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {exp_9_io}]
+set_property SLEW FAST [get_ports {exp_p_io[*]}]
+set_property SLEW FAST [get_ports {exp_n_io[*]}]
+set_property SLEW FAST [get_ports {exp_9_io}]
+set_property DRIVE 8 [get_ports {exp_p_io[*]}]
+set_property DRIVE 8 [get_ports {exp_n_io[*]}]
+set_property DRIVE 8 [get_ports {exp_9_io}]
+
+set_property PACKAGE_PIN W10 [get_ports {exp_p_io[0]}]
+set_property PACKAGE_PIN W9 [get_ports {exp_n_io[0]}]
+set_property PACKAGE_PIN T9 [get_ports {exp_p_io[1]}]
+set_property PACKAGE_PIN U10 [get_ports {exp_n_io[1]}]
+set_property PACKAGE_PIN Y9 [get_ports {exp_p_io[2]}]
+set_property PACKAGE_PIN Y8 [get_ports {exp_n_io[2]}]
+set_property PACKAGE_PIN U9 [get_ports {exp_p_io[3]}]
+set_property PACKAGE_PIN U8 [get_ports {exp_n_io[3]}]
+set_property PACKAGE_PIN V8 [get_ports {exp_p_io[4]}]
+set_property PACKAGE_PIN W8 [get_ports {exp_n_io[4]}]
+set_property PACKAGE_PIN V11 [get_ports {exp_p_io[5]}]
+set_property PACKAGE_PIN V10 [get_ports {exp_n_io[5]}]
+set_property PACKAGE_PIN W11 [get_ports {exp_p_io[6]}]
+set_property PACKAGE_PIN Y11 [get_ports {exp_n_io[6]}]
+set_property PACKAGE_PIN Y12 [get_ports {exp_p_io[7]}]
+set_property PACKAGE_PIN Y13 [get_ports {exp_n_io[7]}]
+set_property PACKAGE_PIN Y7  [get_ports {exp_p_io[8]}]
+set_property PACKAGE_PIN Y6  [get_ports {exp_n_io[8]}]
+set_property PACKAGE_PIN U5  [get_ports {exp_9_io}]
+
+#set_property PULLDOWN TRUE [get_ports {exp_p_io[0]}]
+#set_property PULLDOWN TRUE [get_ports {exp_n_io[0]}]
+#set_property PULLUP   TRUE [get_ports {exp_p_io[7]}]
+#set_property PULLUP   TRUE [get_ports {exp_n_io[7]}]
+
+### SATA connector
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_p_o[*]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_n_o[*]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_p_i[*]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {daisy_n_i[*]}]
+
+set_property PACKAGE_PIN T12 [get_ports {daisy_p_o[0]}]
+set_property PACKAGE_PIN U12 [get_ports {daisy_n_o[0]}]
+set_property PACKAGE_PIN U14 [get_ports {daisy_p_o[1]}]
+set_property PACKAGE_PIN U15 [get_ports {daisy_n_o[1]}]
+set_property PACKAGE_PIN P14 [get_ports {daisy_p_i[0]}]
+set_property PACKAGE_PIN R14 [get_ports {daisy_n_i[0]}]
+set_property PACKAGE_PIN N18 [get_ports {daisy_p_i[1]}]
+set_property PACKAGE_PIN P19 [get_ports {daisy_n_i[1]}]
+
+### LED
+set_property IOSTANDARD LVCMOS33 [get_ports {led_o[*]}]
+set_property SLEW SLOW [get_ports {led_o[*]}]
+set_property DRIVE 4 [get_ports {led_o[*]}]
+
+set_property PACKAGE_PIN K14 [get_ports {led_o[0]}] ; # 0-3 -> 4:7
+set_property PACKAGE_PIN J15 [get_ports {led_o[1]}]
+set_property PACKAGE_PIN J14 [get_ports {led_o[2]}]
+set_property PACKAGE_PIN H15 [get_ports {led_o[3]}]
+set_property PACKAGE_PIN L14 [get_ports {led_o[4]}] ; # 4-7 -> 0:3
+set_property PACKAGE_PIN M14 [get_ports {led_o[5]}]
+set_property PACKAGE_PIN M15 [get_ports {led_o[6]}]
+set_property PACKAGE_PIN N15 [get_ports {led_o[7]}]
+
+############################################################################
+# Clock constraints                                                        #
+############################################################################
+
+create_clock -period 4.000 -name adc_clk [get_ports {adc_clk_i[1]}]
+create_clock -period 4.000 -name dco_clk [get_ports dac_dco_i]
+create_clock -period 100.000 -name pll_ref_i -waveform {0.000 50.000} [get_ports pll_ref_i]
+create_clock -period 4.000 -name rx_clk [get_ports {daisy_p_i[1]}]
+
+create_generated_clock -name i_hk/dna_clk -source [get_pins pll/pll/CLKOUT1] -divide_by 8 [get_pins i_hk/dna_clk_reg/Q]
+
+
+set_clock_groups -asynchronous -group pll_adc_clk -group clk_fpga_0 -group pll_adc_clk2d -group adc_clk
+
+set_clock_groups -asynchronous -group pll_adc_clk2d -group i_hk/dna_clk -group par_clk -group pll_pwm_clk -group pll_ref_i
+
+
+
+
+
+#set_false_path -from [get_clocks clk_fpga_0]    -to [get_clocks pll_adc_clk]
+#set_false_path -from [get_clocks pll_adc_clk]   -to [get_clocks clk_fpga_0]
+
+#set_false_path -from [get_clocks pll_adc_clk2d] -to [get_clocks pll_adc_clk]
+#set_false_path -from [get_clocks pll_adc_clk]   -to [get_clocks pll_adc_clk2d]
+
+#set_false_path -from [get_clocks pll_adc_clk2d] -to [get_clocks pll_pwm_clk]
+#set_false_path -from [get_clocks pll_adc_10mhz] -to [get_clocks pll_adc_clk2d]
+
+
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_n_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_n_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_p_i[0][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -min -add_delay -1.000 [get_ports {adc_dat_p_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -clock_fall -max -add_delay -0.400 [get_ports {adc_dat_p_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -min -add_delay -1.000 [get_ports {adc_dat_p_i[1][*]}]
+set_input_delay -clock [get_clocks adc_clk] -max -add_delay -0.400 [get_ports {adc_dat_p_i[1][*]}]
+
+
+
+
+
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+
+

--- a/pyrpl/fpga/settings.sh
+++ b/pyrpl/fpga/settings.sh
@@ -1,2 +1,2 @@
 
-/opt/Xilinx/Vivado/2015.4/settings64.sh
+/opt/Xilinx/Vivado/2023.2/settings64.sh

--- a/pyrpl/fpga/tight_setup_hold_pins.txt
+++ b/pyrpl/fpga/tight_setup_hold_pins.txt
@@ -1,0 +1,48 @@
++====================+===================+===========================================================================================================================================================+
+| Launch Setup Clock | Launch Hold Clock | Pin                                                                                                                                                       |
++====================+===================+===========================================================================================================================================================+
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk4[4].iir/overflow_reg[0]/D                                                                                                                    |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk6[7].iq_2_outputs/na_sleep_remaining_reg[31]/D                                                                                                |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[31]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk6[7].iq_2_outputs/na_sleep_remaining_reg[25]/D                                                                                                |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[28]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[27]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk6[7].iq_2_outputs/na_averages_remaining_reg[25]/D                                                                                             |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[24]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[23]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[20]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[19]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk6[7].iq_2_outputs/na_averages_remaining_reg[7]/D                                                                                              |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[16]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[15]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_sleep_remaining_reg[5]/D                                                                                                           |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[12]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[11]/D                                                                                                       |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[6]/D                                                                                                        |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[31]/D                                                                                                          |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[7]/D                                                                                                        |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[5]/D                                                                                                        |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[8]/D                                                                                                        |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[28]/D                                                                                                          |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[27]/D                                                                                                          |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[4]/D                                                                                                        |
+| pll_adc_clk        | pll_adc_clk       | i_scope/sys_rdata_reg[28]/D                                                                                                                               |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[24]/D                                                                                                          |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[23]/D                                                                                                          |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.r_channel_0/transaction_fifo_0/cnt_read_reg[4]/D             |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[5].iq/na_averages_remaining_reg[3]/D                                                                                                        |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[11].GEN_REG_STATUS.ip_irpt_status_reg_reg[11]/D              |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[20]/D                                                                                                          |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[19]/D                                                                                                          |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[2]/D |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[14].GEN_REG_STATUS.ip_irpt_status_reg_reg[14]/D              |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[0]/D |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/axi_protocol_converter_0/inst/gen_axilite.gen_b2s_conv.axilite_b2s/RD.ar_channel_0/cmd_translator_0/wrap_cmd_0/wrap_cnt_r_reg[1]/D |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[0].GEN_REG_STATUS.ip_irpt_status_reg_reg[0]/D                |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[4].GEN_REG_STATUS.ip_irpt_status_reg_reg[4]/D                |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[16]/D                                                                                                          |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[7].GEN_REG_STATUS.ip_irpt_status_reg_reg[7]/D                |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[5].GEN_REG_STATUS.ip_irpt_status_reg_reg[5]/D                |
+| pll_adc_clk        | pll_adc_clk       | i_dsp/genblk5[6].iq/na_sleep_remaining_reg[15]/D                                                                                                          |
+| clk_fpga_3         | clk_fpga_3        | i_ps/system_i/system_i/xadc/inst/INTR_CTRLR_GEN_I.INTERRUPT_CONTROL_I/GEN_IP_IRPT_STATUS_REG[15].GEN_REG_STATUS.ip_irpt_status_reg_reg[15]/D              |
++--------------------+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/pyrpl/fpga/vitis_create_fsbl.py
+++ b/pyrpl/fpga/vitis_create_fsbl.py
@@ -1,0 +1,16 @@
+import vitis
+
+client = vitis.create_client()
+client.set_workspace(path="./vitis_proj")
+
+status = client.set_sw_repo(level="LOCAL", path=["../../../device-tree-xlnx-xilinx-v2024.2"])
+
+platform = client.create_platform_component(
+    name = "redpitaya",
+    hw = "./sdk/red_pitaya.xsa",
+    os = "standalone",
+    cpu = "ps7_cortexa9_0")
+
+status = platform.build()
+
+vitis.dispose()

--- a/pyrpl/fpga/xsct_hsi_dtb.tcl
+++ b/pyrpl/fpga/xsct_hsi_dtb.tcl
@@ -1,0 +1,36 @@
+################################################################################
+# XSCT / HSI tcl script for building pyrpl device tree blob
+#
+# Usage:
+# xsct xsct_hsi_dtb.tcl
+################################################################################
+
+
+set prj_name pyrpl
+
+set path_sdk sdk
+
+hsi open_hw_design $path_sdk/red_pitaya.xsa
+
+set ver 2023.2
+foreach item $argv {
+  puts "Input arfguments: $argv"
+  if {[lsearch -all $item "*DTG_VER*"] >= 0} {
+    set param [split $item "="]
+    if {[lindex $param 1] ne ""} {
+      set ver [lindex $param 1]
+    }
+  }
+}
+puts "DTG version: $ver"
+
+hsi set_repo_path ../../../device-tree-xlnx-xilinx-v$ver/
+
+hsi create_sw_design device-tree -os device_tree -proc ps7_cortexa9_0
+
+hsi set_property CONFIG.kernel_version $ver [hsi get_os]
+hsi set_property CONFIG.dt_overlay true [hsi get_os]
+
+hsi generate_target -dir $path_sdk/dts
+
+exit


### PR DESCRIPTION
In this commit I have not changed the original .bin file that remains unchanged.  I have also left the associated reports in out folder unchanged.

This commit will allow people to use Vitis / Vivado v2023.2 to build the pyrpl fpga.  By bringing the build system to v2023 it allows more recent Vitis tools to be used more easily.

Also it pulls in more recent board definitions for more recent RedPitaya boards.

Also it builds the overlay device tree blob that is needed to load fpga and matching device tree onto the RedPitaya boards.

I have tested the generated .bin file and the generated .dtbo device tree with the latest nose tests and have not seen any significant problems.

I have run the IIR filter code with a butterworth low pass filter and get the same results are  with the original pyrpl .bin file and the current eco system v2 pyrpl .bin file.