### PR TITLE
fixes for pyqt 2.4.1

### DIFF
--- a/pyrpl/software_modules/loop.py
+++ b/pyrpl/software_modules/loop.py
@@ -59,7 +59,7 @@ class Loop(Module):
 
     @interval.setter
     def interval(self, val):
-        self.timer.setInterval(val*1000.0)
+        self.timer.setInterval(int(val*1000))
 
     def _clear(self):
         self._ended = True

--- a/pyrpl/widgets/module_widgets/iir_widget.py
+++ b/pyrpl/widgets/module_widgets/iir_widget.py
@@ -11,8 +11,7 @@ from ... import APP
 
 class MyGraphicsWindow(pg.GraphicsLayoutWidget):
     def __init__(self, title, parent):
-        super().__init__(title=title)
-        self.parent = parent
+        super().__init__(parent=parent, title=title)
         self.setToolTip("-----plot legend---------------\n"
                         "yellow: theoretical IIR transfer function\n"
                         "green: data curve\n"
@@ -28,7 +27,7 @@ class MyGraphicsWindow(pg.GraphicsLayoutWidget):
         #APP.setDoubleClickInterval(300)  # default value (550) is fine
         self.mouse_clicked_timer = QtCore.QTimer()
         self.mouse_clicked_timer.setSingleShot(True)
-        self.mouse_clicked_timer.setInterval(APP.doubleClickInterval())
+        self.mouse_clicked_timer.setInterval(int(APP.doubleClickInterval()))
         self.mouse_clicked_timer.timeout.connect(self.mouse_clicked)
 
     # see https://wiki.python.org/moin/PyQt/Distinguishing%20between%20click%20and%20double%20click

--- a/pyrpl/widgets/module_widgets/na_widget.py
+++ b/pyrpl/widgets/module_widgets/na_widget.py
@@ -345,7 +345,7 @@ class NaWidget(AcquisitionModuleWidget):
 
 class MyGraphicsWindow(pg.GraphicsLayoutWidget):
     def __init__(self, title, parent_widget):
-        super(MyGraphicsWindow, self).__init__(title)
+        super().__init__(title = title)
         self.parent_widget = parent_widget
         self.setToolTip("IIR transfer function: \n"
                         "----------------------\n"
@@ -375,4 +375,4 @@ class MyGraphicsWindow(pg.GraphicsLayoutWidget):
         except BaseException as e:
             self.parent_widget.module._logger.error(e)
         finally:
-            return super(GraphicsLayoutWidget, self).mousePressEvent(*args, **kwds)
+            return super().mousePressEvent(*args, **kwds)

--- a/pyrpl/widgets/pyrpl_widget.py
+++ b/pyrpl/widgets/pyrpl_widget.py
@@ -117,7 +117,7 @@ class MyDockWidget(QtWidgets.QDockWidget):
                 self.timer = QtCore.QTimer()
                 self.timer.timeout.connect(fn)
                 self.timer.setSingleShot(True)
-                self.timer.setInterval(1.0)
+                self.timer.setInterval(1)
                 self.timer.start()
             event.accept()
             return True


### PR DESCRIPTION
Here are a few minor python3 / pyqt 2.4.1 changes.  Most notable is that QtCore.QTimer.interval() is an integer, whilst some of the pyrpl code uses float values.  So we should convert to int or supply an int value to be consistent with the Qt api.