### PR TITLE
replace deprecated scipy.misc.derivative with equivalent code

### DIFF
--- a/pyrpl/software_modules/lockbox/input.py
+++ b/pyrpl/software_modules/lockbox/input.py
@@ -344,11 +344,9 @@ class InputSignal(Signal):
         of the variable. May be overwritten by a more efficient (analytical) method
         in a derived class.
         """
-        return scipy.misc.derivative(self.expected_signal,
-                                     variable,
-                                     dx=1e-9,
-                                     n=1,  # first derivative
-                                     order=3)
+        dx = 1e-9
+        df = self.expected_signal(variable + dx) - self.expected_signal(variable - dx)
+        return df / 2 / dx
 
     def is_locked(self, loglevel=logging.INFO):
         """ returns whether the input is locked at the current stage """


### PR DESCRIPTION
scipy 1.10 released in January 2023 deprecated `scipy.misc.derivative`:

https://docs.scipy.org/doc/scipy-1.10.0/release.1.10.0.html#deprecated-features

This function is completely removed from scipy 1.15 released in December 2024:

https://github.com/scipy/scipy/commit/43fc97efa8a617038281e035f8efbc95a96ebff8

This function is only used in [software_modules/lockbox/input.py](https://github.com/pyrpl-fpga/pyrpl/blob/main/pyrpl/software_modules/lockbox/input.py) and can be easily replaced with equivalent code. This is what I propose to do with this pull request.