### PR TITLE
Clarify update fpga api

### DIFF
--- a/pyrpl/redpitaya.py
+++ b/pyrpl/redpitaya.py
@@ -52,7 +52,7 @@ defaultparameters = dict(
     autostart=True,  # autostart the client?
     reloadserver=False,  # reinstall the server at startup if not necessary?
     reloadfpga=True,  # reload the fpga binfile at startup?
-    serverbinfilename='fpga.bit.bin',  # name of the binfile on the server
+    serverbinfilename='fpga.bit.bin',  # name of the binfile on the server and in the device tree overlay file
     serverdtbofilename='fpga.dtbo',  # name of the device tree overlay file on the server
     serverdirname = "//opt//pyrpl//",  # server directory for server app and bitfile
     leds_off=True,  # turn off all GPIO lets at startup (improves analog performance)
@@ -93,7 +93,7 @@ class RedPitaya(object):
             reloadfpga=True,  # reload the fpga bitfile at startup?
             filename='fpga//red_pitaya.bin',  # name of the binfile for the fpga, None is default file
             dtbo_filename='fpga//red_pitaya.dtbo', # name of device tree file, None is the default
-            serverbinfilename='fpga.bit.bin',  # name of the binfile on the server
+            serverbinfilename='fpga.bit.bin',  # name of the binfile on the server and in the device tree overlay file
             serverdtbofilename='fpga.dtbo',  # name of the device tree overlay file on the server
             serverdirname = "//opt//pyrpl//",  # server directory for server app and bitfile
             leds_off=True,  # turn off all GPIO lets at startup (improves analog performance)
@@ -204,7 +204,7 @@ class RedPitaya(object):
         self.start_ssh()
         # start other stuff
         if self.parameters['reloadfpga']:  # flash fpga
-            self.update_fpga()
+            self._update_fpga()
         if self.parameters['reloadserver']:  # reinstall server app
             self.installserver()
         if self.parameters['autostart']:  # start client
@@ -292,17 +292,23 @@ class RedPitaya(object):
             else:
                 break
 
-    def update_fpga(self, filename=None):
+    def update_fpga(self, filename=None, dtbo_filename=None):
+        if self.parameters['reloadfpga']:
+            self.logger.error('FPGA update not completed please configure reloadfpga=False')
+            return
+
+        self._update_fpga(filename, dtbo_filename)
+
+    def _update_fpga(self, filename=None, dtbo_filename=None):
         # For version 2.07 and higher to load a custom fpga use overlay.sh script
         update_custom = ''
         update_cmd = '//opt//redpitaya//sbin//overlay.sh pyrpl'
-        if filename is None:
-            if 'filename' in self.parameters and not self.parameters['filename'] is None:
-                source = self.parameters['filename']
-            else:
-                source = None
+        source = None
+        if 'filename' in self.parameters:
+            source = self.parameters['filename']
 
-        else:
+        if not filename is None:
+            # override
             source = filename
 
         if not source is None and os.path.isfile(source):
@@ -329,22 +335,32 @@ class RedPitaya(object):
             raise IOError("Wrong filename",
                 "The fpga binfile was not found at the expected location. Try passing the arguments "
                 "filename=\"c://github//pyrpl//pyrpl//red_pitaya.bin\" adapted to your installation "
-                "directory of pyrpl: current filename: "+self.parameters['filename'])
+                          "directory of pyrpl: current filename: " + source)
 
-        # send binfile
+        if 0 < len(update_custom):
+            dtbo_source = None
+            if 'dtbo_filename' in self.parameters:
+                dtbo_source = self.parameters['dtbo_filename']
+
+            if not dtbo_filename is None:
+                # override
+                dtbo_source = dtbo_filename
+
+            if not dtbo_source is None:
+                # send device tree
+                update_custom = '{} dtbo'.format(update_custom)
+                if not os.path.isfile(dtbo_source):
+                    raise IOError("Wrong device tree filename",
+                                  "The fpga device tree was not found at the expected location. Try passing the arguments "
+                                  "dtbo_filename=\"c://github//pyrpl//pyrpl//red_pitaya.dtbo\" adapted to your installation "
+                                  "directory of pyrpl: current filename: " + dtbo_source)
+                self.put_file(dtbo_source,
+                              os.path.join(self.parameters['serverdirname'],
+                                           self.parameters['serverdtbofilename']))
+
+        # send binfile after all checks
         self.put_file(source, os.path.join(self.parameters['serverdirname'],
                                            self.parameters['serverbinfilename']))
-        if 0 < len(update_custom) and 'dtbo_filename' in self.parameters and not self.parameters['dtbo_filename'] is None:
-            # send device tree
-            update_custom = '{} dtbo'.format(update_custom)
-            if not os.path.isfile(self.parameters['dtbo_filename']):
-                raise IOError("Wrong device tree filename",
-                  "The fpga device tree was not found at the expected location. Try passing the arguments "
-                  "dtbo_filename=\"c://github//pyrpl//pyrpl//red_pitaya.dtbo\" adapted to your installation "
-                  "directory of pyrpl: current filename: "+self.parameters['dtbo_filename'])
-            self.put_file(self.parameters['dtbo_filename'],
-                          os.path.join(self.parameters['serverdirname'],
-                                       self.parameters['serverdtbofilename']))
 
         # add appropriate parameters to the update command line
         update_cmd = '{} {}'.format(update_cmd, update_custom)
@@ -370,19 +386,10 @@ class RedPitaya(object):
             self.parameters['serverdirname'], self.parameters['serverdtbofilename']))
         self.ssh.ask('rm -f '+ os.path.join(
             self.parameters['serverdirname'], self.parameters['serverbinfilename']))
-        self.ssh.ask('rm -f '+ os.path.join(
-            self.parameters['serverdirname'], 'update_fpga.sh'))
         self.ssh.ask("nginx -p //opt//www//")
         self.ssh.ask('systemctl start redpitaya_nginx')  # for 0.94 and higher
         sleep(self.parameters['delay'])
         self.ssh.ask('ro')
-
-    def fpgaupdateinprogress(self):
-        self.ssh.ask()
-        result = self.ssh.ask('wc {}'.format(os.path.join(self.parameters['serverdirname'], 'update_fpga.sh')))
-        self.logger.debug('wc update_fpga.sh {}'.format(result))
-
-        return result.find('No such file or directory') < 0
 
     def installserver(self):
         self.endserver()
@@ -427,10 +434,6 @@ class RedPitaya(object):
     def startserver(self):
         self.endserver()
         sleep(self.parameters['delay'])
-        if self.fpgaupdateinprogress():
-            self.logger.info("FPGA is being flashed. Please wait for 2 "
-                            "seconds.")
-            sleep(2.0)
         result = self.ssh.ask(self.parameters['serverdirname']+"/"+self.parameters['monitor_server_name']
                           +" "+ str(self.parameters['port']))
         if not "sh" in result: # sh in result means we tried the wrong binary version

--- a/pyrpl/redpitaya.py
+++ b/pyrpl/redpitaya.py
@@ -384,29 +384,6 @@ class RedPitaya(object):
 
         return result.find('No such file or directory') < 0
 
-    def fpgarecentlyflashed(self):
-        self.ssh.ask()
-        result =self.ssh.ask("echo $(($(date +%s) - $(date +%s -r \""
-        + os.path.join(self.parameters['serverdirname'], self.parameters['serverbinfilename']) +"\")))")
-        age = None
-        for line in result.split('\n'):
-            try:
-                age = int(line.strip())
-            except:
-                pass
-            else:
-                break
-        if not age:
-            self.logger.debug("Could not retrieve bitfile age from: %s",
-                            result)
-            return False
-        elif age > 10:
-            self.logger.debug("Found expired bitfile. Age: %s", age)
-            return False
-        else:
-            self.logger.debug("Found recent bitfile. Age: %s", age)
-            return True
-
     def installserver(self):
         self.endserver()
         sleep(self.parameters['delay'])


### PR DESCRIPTION
Here is my proposal for preventing multiple simultaneous attempts to update the fpga

I have also removed the redundant fpgarecentlyflashed() method.

I noticed a few simplifications to the update_fpga code as well, might result in fewer bugs!

**FEATURE**!!
setting reloadfpga = False and using
```
    p = pyrpl.Pyrpl(config = CONFIG, hostname = HOSTNAME, gui = False, reloadfpga = False)
    r = p.rp
    r.update_fpga(filename='red_pitaya_1.bin', dtbo_filename='red_pitaya_1.dtbo')
    r.restart()
```

demonstrates a divide by zero error when used with a configuration file that has already been populated with a test run because the fpga is not loaded so the v94 fpga is in place when the configuration load is started.  It never gets to the update_fpga call because of the register read fails.

Assuming the .yml file has been removed then this set of API calls works well.

So we should expose reloadfpga or the recommended sequence would be something like 
```
    p = pyrpl.Pyrpl(config = CONFIG, hostname = HOSTNAME, gui = False, reloadfpga = True) #, loglevel = 'debug') # False)
    r = p.rp
    r.parameters['reloadfpga'] = False
    r.update_fpga(filename='red_pitaya_1.bin', dtbo_filename='red_pitaya_1.dtbo')
    r.restart()
```

this sequence also works well.

